### PR TITLE
Initial batch of changes to add subscription persistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -169,7 +169,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -191,7 +191,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -229,9 +229,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "bitflags"
@@ -265,9 +265,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -353,14 +353,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -627,9 +627,9 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -643,14 +643,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -788,7 +788,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1095,7 +1095,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1121,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1167,6 +1167,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "jni"
@@ -1275,6 +1299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,7 +1405,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1518,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "openssl-probe"
@@ -1675,7 +1705,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1729,7 +1759,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1823,6 +1853,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,11 +1875,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -1874,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "bytes",
  "once_cell",
@@ -1886,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1901,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1917,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2110,7 +2155,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2159,9 +2204,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2252,7 +2297,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2392,7 +2450,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2443,22 +2501,22 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2469,7 +2527,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2659,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,20 +2734,20 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2717,7 +2775,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2728,7 +2786,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "test-case-core",
 ]
 
@@ -2758,7 +2816,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2769,7 +2827,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2784,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -2799,15 +2857,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2862,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2886,7 +2944,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2946,7 +3004,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3282,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "validated_struct"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef04c049b4beae3037a2a31b8da40d8cebec0b97456f24c7de0ede4ed9efed"
+checksum = "0251cab911130b095b8190d5480729c5e6a05e36e617658039e4bfcfd879c153"
 dependencies = [
  "json5",
  "serde",
@@ -3294,13 +3352,13 @@ dependencies = [
 
 [[package]]
 name = "validated_struct_macros"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4444a980afa9ef0d29c2a3f4d952ec0495a7a996a9c78b52698b71bc21edb4"
+checksum = "dcba0282a9f9297af06b91ff22615e7f77f0ab66f75fc95898960d1604fc7fd7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
  "unzip-n",
 ]
 
@@ -3381,7 +3439,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -3403,7 +3461,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3454,7 +3512,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -3709,7 +3767,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -4040,7 +4098,7 @@ checksum = "5aa21d01ec1ea1cb5c6988e5ec2ac67d80ebd8ba007dc11434fbd00cea51e137"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "zenoh-keyexpr",
 ]
 
@@ -4194,8 +4252,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -4206,7 +4272,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4226,7 +4303,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -4255,5 +4332,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.100",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "array-init"
@@ -157,7 +157,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -169,7 +169,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -185,13 +185,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -235,9 +235,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -271,9 +271,9 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -298,16 +298,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -360,7 +360,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -621,15 +621,15 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "env_filter"
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -788,7 +788,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "humantime"
@@ -1095,7 +1095,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -1238,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -1276,9 +1276,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lz4_flex"
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "mediatype"
-version = "0.19.18"
+version = "0.19.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8878cd8d1b3c8c8ae4b2ba0a36652b7cf192f618a599a7fbdfa25cffd4ea72dd"
+checksum = "33746aadcb41349ec291e7f2f0a3aa6834d1d7c58066fb4b01f68efc4c4b7631"
 
 [[package]]
 name = "memchr"
@@ -1334,9 +1334,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1375,7 +1375,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1530,18 +1530,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -1651,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -1675,7 +1675,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1729,7 +1729,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1739,6 +1739,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pickledb"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c53a5ade47760e8cc4986bdc5e72daeffaaaee64cbc374f9cfe0a00c1cd87b1f"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1776,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnet_base"
@@ -1855,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1984,7 +1994,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -2004,7 +2014,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2012,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2026,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -2065,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -2085,22 +2095,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2149,15 +2159,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2249,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
@@ -2333,15 +2342,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2363,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "either",
@@ -2376,14 +2385,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2428,28 +2437,28 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2460,14 +2469,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2580,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -2650,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2667,14 +2676,14 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2708,7 +2717,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2719,7 +2728,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "test-case-core",
 ]
 
@@ -2734,11 +2743,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2749,18 +2758,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2816,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2837,7 +2846,7 @@ checksum = "0d4511e6fec190f1b99c16d4b53982bcb449295e7ce165d361a673f7ad09339e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",
 ]
@@ -2877,14 +2886,14 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2937,7 +2946,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3022,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -3048,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"
@@ -3128,11 +3137,11 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "env_logger",
- "futures",
  "log",
  "mockall",
+ "pickledb",
  "protobuf",
- "semver",
+ "serde",
  "test-case",
  "tokio",
  "up-rust 0.4.0",
@@ -3143,17 +3152,11 @@ dependencies = [
 name = "up-subscription-cli"
 version = "0.2.0"
 dependencies = [
- "async-trait",
  "clap",
  "clap-num",
  "daemonize",
- "env_logger",
- "futures",
  "log",
- "mockall",
- "protobuf",
  "serde_json",
- "test-case",
  "tokio",
  "up-rust 0.4.0",
  "up-subscription",
@@ -3260,9 +3263,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
 ]
@@ -3378,7 +3381,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -3400,7 +3403,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3493,6 +3496,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -3700,7 +3709,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -4031,7 +4040,7 @@ checksum = "5aa21d01ec1ea1cb5c6988e5ec2ac67d80ebd8ba007dc11434fbd00cea51e137"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "zenoh-keyexpr",
 ]
 
@@ -4197,27 +4206,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -4246,5 +4255,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ version = "0.2.0"
 [workspace.dependencies]
 async-trait = { version = "0.1" }
 env_logger = { version = "0.11" }
-futures = { version = "0.3" }
 log = { version = "0.4" }
 mockall = { version = "0.13" }
 protobuf = { version = "3.4" }

--- a/deny.toml
+++ b/deny.toml
@@ -33,8 +33,6 @@ allow = [
     "Unicode-3.0",
     "Zlib",
 ]
-exceptions = [{ name = "ring", allow = ["OpenSSL"] }]
-#private = { ignore = true }
 
 [[licenses.clarify]]
 name = "ring"

--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,7 @@
 # For all options see https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml
 
 [advisories]
-ignore = ["RUSTSEC-2023-0071"]
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2025-0014", "RUSTSEC-2024-0436"]
 
 [bans]
 multiple-versions = "allow"

--- a/up-subscription-cli/Cargo.toml
+++ b/up-subscription-cli/Cargo.toml
@@ -34,13 +34,9 @@ mqtt5 = ["dep:up-transport-mqtt5"]
 zenoh = ["dep:up-transport-zenoh", "dep:serde_json"]
 
 [dependencies]
-async-trait = { workspace = true }
 clap = { version = "4.5", features = ["derive", "env"] }
 clap-num = { version = "1.1" }
-env_logger = { workspace = true }
-futures = { workspace = true }
 log = { workspace = true }
-protobuf = { workspace = true }
 serde_json = { version = "1.0.138", optional = true }
 tokio = { workspace = true }
 up-rust = { workspace = true }
@@ -52,7 +48,3 @@ up-transport-zenoh = { version = "0.5.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5" }
-
-[dev-dependencies]
-mockall = { workspace = true }
-test-case = { workspace = true }

--- a/up-subscription-cli/src/main.rs
+++ b/up-subscription-cli/src/main.rs
@@ -102,7 +102,15 @@ pub(crate) struct Args {
     #[arg(short, long, env, value_parser=between_1_and_1024)]
     notification_buffer: Option<usize>,
 
-    /// Increase verbosity of output
+    /// Enable or disable persistency, default is true (enable)
+    #[arg(short, long, env, default_value_t = true)]
+    persistency: bool,
+
+    /// Filesystem location for storing persistent data, default is current working directory
+    #[arg(long, env)]
+    storage_path: Option<String>,
+
+    /// Increase verbosity of output, default is false (reduced verbosity)
     #[arg(short, long, env, default_value_t = false)]
     verbose: bool,
 
@@ -204,5 +212,7 @@ fn config_from_args(args: &Args) -> Result<USubscriptionConfiguration, Configura
         authority.to_string(),
         args.notification_buffer,
         args.subscription_buffer,
+        args.persistency,
+        args.storage_path.clone(),
     )
 }

--- a/up-subscription/Cargo.toml
+++ b/up-subscription/Cargo.toml
@@ -24,10 +24,10 @@ version.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 env_logger = { workspace = true }
-futures = { workspace = true }
 log = { workspace = true }
+pickledb = { version = "0.5.1" }
 protobuf = { workspace = true }
-semver = { version = "1.0" }
+serde = { version = "1.0" }
 tokio = { workspace = true }
 up-rust = { workspace = true }
 uriparse = { version = "0.6" }

--- a/up-subscription/src/handlers/fetch_subscribers.rs
+++ b/up-subscription/src/handlers/fetch_subscribers.rs
@@ -13,13 +13,7 @@
 
 use async_trait::async_trait;
 use log::*;
-use std::sync::Arc;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
-
-use crate::{
-    helpers,
-    subscription_manager::{SubscribersResponse, SubscriptionEvent},
-};
 
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
@@ -30,12 +24,17 @@ use up_rust::{
     UAttributes,
 };
 
+use crate::{
+    helpers,
+    subscription_manager::{SubscribersResponse, SubscriptionEvent},
+};
+
 pub(crate) struct FetchSubscribersRequestHandler {
-    subscription_sender: Arc<Sender<SubscriptionEvent>>,
+    subscription_sender: Sender<SubscriptionEvent>,
 }
 
 impl FetchSubscribersRequestHandler {
-    pub(crate) fn new(subscription_sender: Arc<Sender<SubscriptionEvent>>) -> Self {
+    pub(crate) fn new(subscription_sender: Sender<SubscriptionEvent>) -> Self {
         Self {
             subscription_sender,
         }
@@ -136,7 +135,7 @@ mod tests {
             mpsc::channel::<SubscriptionEvent>(1);
 
         // create and spawn off handler, to make all the asnync goodness work
-        let request_handler = FetchSubscribersRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscribersRequestHandler::new(subscription_sender);
         tokio::spawn(async move {
             let result = request_handler
                 .handle_request(
@@ -183,7 +182,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscribersRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscribersRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(
@@ -212,7 +211,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscribersRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscribersRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(
@@ -242,7 +241,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscribersRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscribersRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(RESOURCE_ID_FETCH_SUBSCRIBERS, &message_attributes, None)
@@ -271,7 +270,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscribersRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscribersRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(

--- a/up-subscription/src/handlers/fetch_subscriptions.rs
+++ b/up-subscription/src/handlers/fetch_subscriptions.rs
@@ -13,15 +13,7 @@
 
 use async_trait::async_trait;
 use log::*;
-use std::sync::Arc;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
-
-use crate::{
-    helpers,
-    subscription_manager::{
-        RequestKind, SubscriptionEntry, SubscriptionEvent, SubscriptionsResponse,
-    },
-};
 
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
@@ -32,12 +24,19 @@ use up_rust::{
     UAttributes,
 };
 
+use crate::{
+    helpers,
+    subscription_manager::{
+        RequestKind, SubscriptionEntry, SubscriptionEvent, SubscriptionsResponse,
+    },
+};
+
 pub(crate) struct FetchSubscriptionsRequestHandler {
-    subscription_sender: Arc<Sender<SubscriptionEvent>>,
+    subscription_sender: Sender<SubscriptionEvent>,
 }
 
 impl FetchSubscriptionsRequestHandler {
-    pub(crate) fn new(subscription_sender: Arc<Sender<SubscriptionEvent>>) -> Self {
+    pub(crate) fn new(subscription_sender: Sender<SubscriptionEvent>) -> Self {
         Self {
             subscription_sender,
         }
@@ -176,7 +175,7 @@ mod tests {
             mpsc::channel::<SubscriptionEvent>(1);
 
         // create and spawn off handler, to make all the asnync goodness work
-        let request_handler = FetchSubscriptionsRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscriptionsRequestHandler::new(subscription_sender);
         tokio::spawn(async move {
             let result = request_handler
                 .handle_request(
@@ -234,7 +233,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscriptionsRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscriptionsRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(
@@ -263,7 +262,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscriptionsRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscriptionsRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(
@@ -293,7 +292,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscriptionsRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscriptionsRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(RESOURCE_ID_FETCH_SUBSCRIPTIONS, &message_attributes, None)
@@ -322,7 +321,7 @@ mod tests {
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = FetchSubscriptionsRequestHandler::new(Arc::new(subscription_sender));
+        let request_handler = FetchSubscriptionsRequestHandler::new(subscription_sender);
 
         let result = request_handler
             .handle_request(

--- a/up-subscription/src/handlers/register_for_notifications.rs
+++ b/up-subscription/src/handlers/register_for_notifications.rs
@@ -13,10 +13,7 @@
 
 use async_trait::async_trait;
 use log::*;
-use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
-
-use crate::{helpers, notification_manager::NotificationEvent};
 
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
@@ -26,12 +23,14 @@ use up_rust::{
     UAttributes,
 };
 
+use crate::{helpers, notification_manager::NotificationEvent};
+
 pub(crate) struct RegisterNotificationsRequestHandler {
-    notification_sender: Arc<Sender<NotificationEvent>>,
+    notification_sender: Sender<NotificationEvent>,
 }
 
 impl RegisterNotificationsRequestHandler {
-    pub(crate) fn new(notification_sender: Arc<Sender<NotificationEvent>>) -> Self {
+    pub(crate) fn new(notification_sender: Sender<NotificationEvent>) -> Self {
         Self {
             notification_sender,
         }
@@ -106,8 +105,7 @@ mod tests {
             mpsc::channel::<NotificationEvent>(1);
 
         // create and spawn off handler, to make all the asnync goodness work
-        let request_handler =
-            RegisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = RegisterNotificationsRequestHandler::new(notification_sender);
         tokio::spawn(async move {
             let result = request_handler
                 .handle_request(
@@ -152,8 +150,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            RegisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = RegisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -183,8 +180,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            RegisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = RegisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -213,8 +209,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            RegisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = RegisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -246,8 +241,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            RegisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = RegisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(

--- a/up-subscription/src/handlers/unregister_for_notifications.rs
+++ b/up-subscription/src/handlers/unregister_for_notifications.rs
@@ -13,10 +13,7 @@
 
 use async_trait::async_trait;
 use log::*;
-use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
-
-use crate::{helpers, notification_manager::NotificationEvent};
 
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
@@ -26,12 +23,14 @@ use up_rust::{
     UAttributes,
 };
 
+use crate::{helpers, notification_manager::NotificationEvent};
+
 pub(crate) struct UnregisterNotificationsRequestHandler {
-    notification_sender: Arc<Sender<NotificationEvent>>,
+    notification_sender: Sender<NotificationEvent>,
 }
 
 impl UnregisterNotificationsRequestHandler {
-    pub(crate) fn new(notification_sender: Arc<Sender<NotificationEvent>>) -> Self {
+    pub(crate) fn new(notification_sender: Sender<NotificationEvent>) -> Self {
         Self {
             notification_sender,
         }
@@ -100,8 +99,7 @@ mod tests {
             mpsc::channel::<NotificationEvent>(1);
 
         // create and spawn off handler, to make all the asnync goodness work
-        let request_handler =
-            UnregisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = UnregisterNotificationsRequestHandler::new(notification_sender);
         tokio::spawn(async move {
             let result = request_handler
                 .handle_request(
@@ -145,8 +143,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            UnregisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = UnregisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -176,8 +173,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            UnregisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = UnregisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -206,8 +202,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            UnregisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = UnregisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -239,8 +234,7 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler =
-            UnregisterNotificationsRequestHandler::new(Arc::new(notification_sender));
+        let request_handler = UnregisterNotificationsRequestHandler::new(notification_sender);
 
         let result = request_handler
             .handle_request(

--- a/up-subscription/src/handlers/unsubscribe.rs
+++ b/up-subscription/src/handlers/unsubscribe.rs
@@ -13,12 +13,7 @@
 
 use async_trait::async_trait;
 use log::*;
-use std::sync::Arc;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
-
-use crate::{
-    helpers, notification_manager::NotificationEvent, subscription_manager::SubscriptionEvent,
-};
 
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
@@ -28,15 +23,19 @@ use up_rust::{
     UAttributes,
 };
 
+use crate::{
+    helpers, notification_manager::NotificationEvent, subscription_manager::SubscriptionEvent,
+};
+
 pub(crate) struct UnubscribeRequestHandler {
-    subscription_sender: Arc<Sender<SubscriptionEvent>>,
-    notification_sender: Arc<Sender<NotificationEvent>>,
+    subscription_sender: Sender<SubscriptionEvent>,
+    notification_sender: Sender<NotificationEvent>,
 }
 
 impl UnubscribeRequestHandler {
     pub(crate) fn new(
-        subscription_sender: Arc<Sender<SubscriptionEvent>>,
-        notification_sender: Arc<Sender<NotificationEvent>>,
+        subscription_sender: Sender<SubscriptionEvent>,
+        notification_sender: Sender<NotificationEvent>,
     ) -> Self {
         Self {
             subscription_sender,
@@ -141,10 +140,8 @@ mod tests {
             mpsc::channel::<NotificationEvent>(1);
 
         // create and spawn off handler, to make all the asnync goodness work
-        let request_handler = UnubscribeRequestHandler::new(
-            Arc::new(subscription_sender),
-            Arc::new(notification_sender),
-        );
+        let request_handler =
+            UnubscribeRequestHandler::new(subscription_sender, notification_sender);
         tokio::spawn(async move {
             let result = request_handler
                 .handle_request(
@@ -223,10 +220,8 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = UnubscribeRequestHandler::new(
-            Arc::new(subscription_sender),
-            Arc::new(notification_sender),
-        );
+        let request_handler =
+            UnubscribeRequestHandler::new(subscription_sender, notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -256,10 +251,8 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = UnubscribeRequestHandler::new(
-            Arc::new(subscription_sender),
-            Arc::new(notification_sender),
-        );
+        let request_handler =
+            UnubscribeRequestHandler::new(subscription_sender, notification_sender);
 
         let result = request_handler
             .handle_request(
@@ -290,10 +283,8 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = UnubscribeRequestHandler::new(
-            Arc::new(subscription_sender),
-            Arc::new(notification_sender),
-        );
+        let request_handler =
+            UnubscribeRequestHandler::new(subscription_sender, notification_sender);
 
         let result = request_handler
             .handle_request(RESOURCE_ID_UNSUBSCRIBE, &message_attributes, None)
@@ -323,10 +314,8 @@ mod tests {
         let (notification_sender, _) = mpsc::channel::<NotificationEvent>(1);
 
         // create handler and perform tested operation
-        let request_handler = UnubscribeRequestHandler::new(
-            Arc::new(subscription_sender),
-            Arc::new(notification_sender),
-        );
+        let request_handler =
+            UnubscribeRequestHandler::new(subscription_sender, notification_sender);
 
         let result = request_handler
             .handle_request(

--- a/up-subscription/src/lib.rs
+++ b/up-subscription/src/lib.rs
@@ -34,20 +34,20 @@ For a batteries-included approach to running up-subscription-rust, the `up-subsc
 
 */
 
-mod common {
-    pub(crate) mod helpers;
-}
-pub use common::helpers::init_once;
-pub(crate) use common::*;
+// public interface for configuring and starting usubscription service
+mod usubscription;
+pub use usubscription::*;
+mod configuration;
+pub use configuration::{ConfigurationError, USubscriptionConfiguration};
 
+// actors implementing the backend management logic for tracking subscriptions etc
 mod notification_manager;
 mod subscription_manager;
 
-mod configuration;
-pub use usubscription::*;
-mod usubscription;
-pub use configuration::{ConfigurationError, USubscriptionConfiguration};
+// persistent storage for backend data
+mod persistency;
 
+// RpcServer handler functions, first-level input validation and dispatch to backend logic
 pub(crate) mod handlers {
     pub(crate) mod fetch_subscribers;
     pub(crate) mod fetch_subscriptions;
@@ -56,6 +56,13 @@ pub(crate) mod handlers {
     pub(crate) mod unregister_for_notifications;
     pub(crate) mod unsubscribe;
 }
+
+// misc other little helpers and convenience functions
+mod common {
+    pub(crate) mod helpers;
+}
+pub use common::helpers::init_once;
+pub(crate) use common::*;
 
 #[cfg(test)]
 mod tests;

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -1,0 +1,554 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use pickledb::{PickleDb, PickleDbDumpPolicy, SerializationMethod};
+use protobuf::{Enum, Message};
+use serde::de::Error;
+#[cfg(test)]
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::{convert::TryInto, path::PathBuf};
+
+use up_rust::{core::usubscription::State as TopicState, UUri};
+
+use crate::USubscriptionConfiguration;
+
+// Whether to include 'up:' in serialized UUris
+const PERSIST_UP_SCHEMA: bool = true;
+
+#[derive(Debug)]
+pub(crate) enum PersistencyError {
+    InternalError(String),
+    SerializationError(String),
+}
+
+impl PersistencyError {
+    pub(crate) fn serialization_error<T>(message: T) -> PersistencyError
+    where
+        T: Into<String>,
+    {
+        Self::SerializationError(message.into())
+    }
+
+    pub(crate) fn internal_error<T>(message: T) -> PersistencyError
+    where
+        T: Into<String>,
+    {
+        Self::InternalError(message.into())
+    }
+}
+
+impl std::fmt::Display for PersistencyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SerializationError(e) => f.write_fmt(format_args!("Serialization error: {}", e)),
+            Self::InternalError(e) => f.write_fmt(format_args!("Internal error: {}", e)),
+        }
+    }
+}
+
+impl std::error::Error for PersistencyError {}
+
+/// Persistent store for tracking subscriber-topic relationships
+pub(crate) struct SubscriptionsStore {
+    persistency: PickleDb,
+}
+
+impl SubscriptionsStore {
+    const SUBSCRIPTION_STORE_NAME: &str = ".subscriptions.store";
+
+    pub(crate) fn new(configuration: &USubscriptionConfiguration) -> SubscriptionsStore {
+        SubscriptionsStore {
+            persistency: get_store(
+                SubscriptionsStore::SUBSCRIPTION_STORE_NAME.to_string(),
+                configuration.persistency_path.clone(),
+                configuration.persistency_enabled,
+            ),
+        }
+    }
+
+    /// Add a new topic-subscriber relationship to persistent storage
+    /// * any such relationship in this store implies a subscription state of SUBSCRIBED, except for remote topics (refer to `RemoteTopicsStore`)
+    /// * returns `Ok(true)` if this is the first subscription to this topic, `Ok(false)` otherwise
+    /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
+    pub(crate) fn add_subscription(
+        &mut self,
+        subscriber: &UUri,
+        topic: &UUri,
+    ) -> Result<bool, PersistencyError> {
+        // serialize inputs to types used in persistency
+        let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
+        let subscriber_string = &subscriber.to_uri(PERSIST_UP_SCHEMA);
+
+        Ok(
+            if let Some(mut subscriber_list) = self.persistency.get::<HashSet<String>>(topic_string)
+            {
+                subscriber_list.insert(subscriber_string.clone());
+                self.persistency
+                    .set(topic_string, &subscriber_list)
+                    .map_err(|e| {
+                        PersistencyError::internal_error(format!(
+                            "Error updating topic-subscriber list {e}"
+                        ))
+                    })?;
+                false
+            } else {
+                self.persistency
+                    .set(topic_string, &HashSet::from([subscriber_string.clone()]))
+                    .map_err(|e| {
+                        PersistencyError::internal_error(format!(
+                            "Error adding new topic-subscriber {e}"
+                        ))
+                    })?;
+                true
+            },
+        )
+    }
+
+    /// Removes a topic-subscriber combination from persistent storage
+    /// * returns `Ok(true)` if this was the last subscriber to the topic, `Ok(false)` otherwise
+    /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
+    pub(crate) fn remove_subscription(
+        &mut self,
+        subscriber: &UUri,
+        topic: &UUri,
+    ) -> Result<bool, PersistencyError> {
+        // serialize inputs to types used in persistency
+        let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
+        let subscriber_string = &subscriber.to_uri(PERSIST_UP_SCHEMA);
+
+        if let Some(mut subscriber_list) = self.persistency.get::<HashSet<String>>(topic_string) {
+            subscriber_list.remove(subscriber_string);
+
+            if subscriber_list.is_empty() {
+                let _r = self.persistency.rem(topic_string).map_err(|e| {
+                    PersistencyError::internal_error(format!(
+                        "Error removing topic-subscriber list {e}"
+                    ))
+                })?;
+                return Ok(true);
+            } else {
+                self.persistency
+                    .set(topic_string, &subscriber_list)
+                    .map_err(|e| {
+                        PersistencyError::internal_error(format!(
+                            "Error storing updated topic-subscriber list {e}"
+                        ))
+                    })?;
+            }
+        };
+        Ok(false)
+    }
+
+    /// Return a list of all subscribers of given topic
+    /// * returns `Vec<UUri>` that contains all subscriber UUris registered for the topic
+    /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
+    pub(crate) fn get_topic_subscribers(
+        &self,
+        topic: &UUri,
+    ) -> Result<Vec<UUri>, PersistencyError> {
+        let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
+        let mut subscribers = vec![];
+
+        // This will get *every* client that subscribed to `topic` - no matter whether (in the case of remote subscriptions)
+        // the remote topic is already fully SUBSCRIBED, of still SUSBCRIBED_PENDING
+        if let Some(list) = self.persistency.get::<HashSet<String>>(topic_string) {
+            for entry in list {
+                subscribers.push(UUri::try_from(entry).map_err(|e| {
+                    PersistencyError::serialization_error(format!(
+                        "Error deserializing subscriber uri {e}"
+                    ))
+                })?);
+            }
+        }
+
+        Ok(subscribers)
+    }
+
+    /// Return a list of all topics subscribed to by given subscriber
+    /// * returns `Vec<UUri>` that contains all topics subscribed to by subscriber
+    /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
+    pub(crate) fn get_subscriber_topics(
+        &self,
+        subscriber: &UUri,
+    ) -> Result<Vec<UUri>, PersistencyError> {
+        let subscriber_string = &subscriber.to_uri(PERSIST_UP_SCHEMA);
+        let mut result_subs: Vec<UUri> = Vec::new();
+
+        for entry in self.persistency.iter() {
+            if let Some(subscribers) = entry.get_value::<HashSet<String>>() {
+                if subscribers.contains(subscriber_string) {
+                    result_subs.push(UUri::try_from(entry.get_key()).map_err(|e| {
+                        PersistencyError::serialization_error(format!(
+                            "Error deserializing topic uri {e}"
+                        ))
+                    })?);
+                }
+            }
+        }
+
+        Ok(result_subs)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_data(
+        &self,
+    ) -> Result<HashMap<UUri, HashSet<UUri>>, Box<dyn std::error::Error>> {
+        #[allow(clippy::mutable_key_type)]
+        let mut map: HashMap<UUri, HashSet<UUri>> = HashMap::new();
+
+        for entry in self.persistency.iter() {
+            #[allow(clippy::mutable_key_type)]
+            let mut topic_subscribers = HashSet::new();
+
+            if let Some(list) = entry.get_value::<HashSet<String>>() {
+                for entry in list {
+                    topic_subscribers.insert(UUri::try_from(entry).map_err(|e| {
+                        PersistencyError::serialization_error(format!(
+                            "Error deserializing subscriber uri {e}"
+                        ))
+                    })?);
+                }
+            }
+
+            map.insert(
+                UUri::try_from(entry.get_key()).map_err(|e| {
+                    PersistencyError::serialization_error(format!(
+                        "Error deserializing topic uri {e}"
+                    ))
+                })?,
+                topic_subscribers,
+            );
+        }
+        Ok(map)
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::mutable_key_type)]
+    pub(crate) fn set_data(
+        &mut self,
+        map: HashMap<UUri, HashSet<UUri>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for (topic, subscribers) in map {
+            self.persistency
+                .set(
+                    &topic.to_uri(PERSIST_UP_SCHEMA),
+                    &subscribers
+                        .iter()
+                        .map(|u| u.to_uri(PERSIST_UP_SCHEMA))
+                        .collect::<HashSet<String>>(),
+                )
+                .map_err(|e| {
+                    PersistencyError::serialization_error(format!(
+                        "Error storing topic-subscriber data in persistency {e}"
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+}
+
+/// Persistent store for tracking remote topic status
+pub(crate) struct RemoteTopicsStore {
+    persistency: PickleDb,
+}
+
+impl RemoteTopicsStore {
+    const PERSIST_UP_SCHEMA: bool = true;
+    const REMOTE_TOPICS_STORE_NAME: &str = ".remote_topics.store";
+
+    pub(crate) fn new(configuration: &USubscriptionConfiguration) -> RemoteTopicsStore {
+        RemoteTopicsStore {
+            persistency: get_store(
+                RemoteTopicsStore::REMOTE_TOPICS_STORE_NAME.to_string(),
+                configuration.persistency_path.clone(),
+                configuration.persistency_enabled,
+            ),
+        }
+    }
+
+    /// Get subscription state of topic
+    /// * returns `Ok(Some(TopicState))` (with current TopicState value) if topic exists in store, otherwise returns `Ok(None)`
+    /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
+    pub(crate) fn get_topic_state(
+        &self,
+        topic: &UUri,
+    ) -> Result<Option<TopicState>, PersistencyError> {
+        let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
+
+        Ok(if self.persistency.exists(topic_string) {
+            let bytes = self.persistency.get::<Vec<u8>>(topic_string).ok_or(
+                PersistencyError::internal_error(
+                    "Error retrieving remote topic state from persistency",
+                ),
+            )?;
+            Some(deserialize_topic_state(&bytes).map_err(|e| {
+                PersistencyError::serialization_error(format!(
+                    "Error deserializing topic state {e}"
+                ))
+            })?)
+        } else {
+            None
+        })
+    }
+
+    /// Update subscription state of topic in remote-topics store
+    /// * returns `Ok(TopicState)` (with updated TopicState value) if state update is successful
+    /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
+    pub(crate) fn set_topic_state(
+        &mut self,
+        topic: &UUri,
+        state: TopicState,
+    ) -> Result<TopicState, PersistencyError> {
+        let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
+        let bytes = serialize_topic_state(&state).map_err(|e| {
+            PersistencyError::serialization_error(format!("Error serializing topic state {e}"))
+        })?;
+
+        self.persistency.set(topic_string, &bytes).map_err(|e| {
+            PersistencyError::internal_error(format!(
+                "Error setting remote topic state in persistency {e}"
+            ))
+        })?;
+
+        Ok(state)
+    }
+
+    /// Get subscription state of remote topic, or adds new remote-topic with state TopicState::SUBSCRIBE_PENDING if topic is new
+    /// * returns `Ok(TopicState)` (where TopicState is the new topic state)
+    /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
+    pub(crate) fn add_topic_or_get_state(
+        &mut self,
+        topic: &UUri,
+    ) -> Result<TopicState, PersistencyError> {
+        let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
+
+        // if remote topic already has been registered, retrieve state
+        Ok(if self.persistency.exists(topic_string) {
+            let bytes = self.persistency.get::<Vec<u8>>(topic_string).ok_or(
+                PersistencyError::internal_error(
+                    "Error retrieving remote topic state from persistency",
+                ),
+            )?;
+            deserialize_topic_state(&bytes).map_err(|e| {
+                PersistencyError::serialization_error(format!(
+                    "Error deserializing topic state {e}"
+                ))
+            })?
+        } else {
+            self.set_topic_state(topic, TopicState::SUBSCRIBE_PENDING)?
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_data(&self) -> Result<HashMap<UUri, TopicState>, Box<dyn std::error::Error>> {
+        #[allow(clippy::mutable_key_type)]
+        let mut map: HashMap<UUri, TopicState> = HashMap::new();
+
+        for kv in self.persistency.iter() {
+            if let Some(bytes) = kv.get_value::<Vec<u8>>() {
+                let value = deserialize_topic_state(&bytes)?;
+                map.insert(UUri::try_from(kv.get_key())?, value);
+            }
+        }
+
+        Ok(map)
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::mutable_key_type)]
+    pub(crate) fn set_data(
+        &mut self,
+        map: HashMap<UUri, TopicState>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for (key, value) in map {
+            let _r = self.persistency.set(
+                &key.to_uri(Self::PERSIST_UP_SCHEMA),
+                &serialize_topic_state(&value)?,
+            );
+        }
+        Ok(())
+    }
+}
+
+pub(crate) struct NotificationStore {
+    persistency: PickleDb,
+}
+
+impl NotificationStore {
+    const PERSIST_UP_SCHEMA: bool = true;
+    const NOTIFICATION_STORE_NAME: &str = ".notification.store";
+
+    pub(crate) fn new(configuration: &USubscriptionConfiguration) -> NotificationStore {
+        NotificationStore {
+            persistency: get_store(
+                NotificationStore::NOTIFICATION_STORE_NAME.to_string(),
+                configuration.persistency_path.clone(),
+                configuration.persistency_enabled,
+            ),
+        }
+    }
+
+    /// Add subscriber to custom-notifications store
+    /// * return `Ok(())` on success
+    /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
+    pub(crate) fn add_notifyee(
+        &mut self,
+        subscriber: &UUri,
+        topic: &UUri,
+    ) -> Result<(), PersistencyError> {
+        let subscriber_string = subscriber.to_uri(Self::PERSIST_UP_SCHEMA);
+        let topic_bytes = serialize_uuri(topic)
+            .map_err(|e| PersistencyError::serialization_error(e.to_string()))?;
+
+        self.persistency
+            .set(&subscriber_string, &topic_bytes)
+            .map_err(|e| {
+                PersistencyError::internal_error(format!(
+                    "Error setting notification configuration in persistency {e}"
+                ))
+            })
+    }
+
+    /// Remove subscriber from custom-notifications store
+    /// * return `Ok(())` on success
+    /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
+    pub(crate) fn remove_notifyee(&mut self, subscriber: &UUri) -> Result<(), PersistencyError> {
+        self.persistency
+            .rem(&subscriber.to_uri(Self::PERSIST_UP_SCHEMA))
+            .map_err(|e| {
+                PersistencyError::internal_error(format!(
+                    "Error setting notification configuration in persistency {e}"
+                ))
+            })?;
+
+        Ok(())
+    }
+
+    /// Get a list of all topic keys from custom notification persistency
+    /// * return a `Vec<UUri>` list of topic UUris
+    /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
+    pub(crate) fn get_topics(&mut self) -> Result<Vec<UUri>, PersistencyError> {
+        let mut result = vec![];
+
+        for entry in self.persistency.iter() {
+            if let Some(bytes) = entry.get_value::<Vec<u8>>() {
+                let topic = deserialize_uuri(&bytes).map_err(|e| {
+                    PersistencyError::serialization_error(format!(
+                        "Error deserializing notification topic {e}"
+                    ))
+                })?;
+                result.push(topic);
+            }
+        }
+        Ok(result)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_data(&self) -> Result<HashMap<UUri, UUri>, Box<dyn std::error::Error>> {
+        #[allow(clippy::mutable_key_type)]
+        let mut map: HashMap<UUri, UUri> = HashMap::new();
+
+        for kv in self.persistency.iter() {
+            if let Some(bytes) = kv.get_value::<Vec<u8>>() {
+                let value = deserialize_uuri(&bytes)?;
+                map.insert(UUri::try_from(kv.get_key())?, value);
+            }
+        }
+
+        Ok(map)
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::mutable_key_type)]
+    pub(crate) fn set_data(
+        &mut self,
+        map: HashMap<UUri, UUri>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for (key, value) in map {
+            let _r = self
+                .persistency
+                .set(&key.to_uri(PERSIST_UP_SCHEMA), &serialize_uuri(&value)?);
+        }
+        Ok(())
+    }
+}
+
+// custom serialization functions
+fn serialize_uuri(uuri: &UUri) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    Ok(uuri.write_to_bytes()?)
+}
+
+fn deserialize_uuri(bytes: &[u8]) -> Result<UUri, Box<dyn std::error::Error>> {
+    Ok(UUri::parse_from_bytes(bytes)?)
+}
+
+fn serialize_topic_state(state: &TopicState) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    Ok(state.value().to_le_bytes().to_vec())
+}
+
+fn deserialize_topic_state(bytes: &[u8]) -> Result<TopicState, Box<dyn std::error::Error>> {
+    Ok(
+        TopicState::from_i32(i32::from_le_bytes(bytes[..4].try_into()?))
+            .ok_or_else(|| serde::de::value::Error::custom("Invalid TopicState value"))?,
+    )
+}
+
+// Return a notification store instance, configured according to a USubscriptionConfiguration
+fn get_store(name: String, path: PathBuf, persistency_enabled: bool) -> PickleDb {
+    // duplicate policy returns, because there is no way to `clone()` this thing - and I need two instances below for load / new calls
+    let (path, policy_load, policy_new) = {
+        let path = validate_and_append_filename(&path, &name)
+            .unwrap_or_else(|e| panic!("Problem with persistency, invalid storage file name: {e}"));
+
+        if persistency_enabled {
+            (
+                path,
+                PickleDbDumpPolicy::AutoDump,
+                PickleDbDumpPolicy::AutoDump,
+            )
+        } else {
+            (
+                path,
+                PickleDbDumpPolicy::NeverDump,
+                PickleDbDumpPolicy::NeverDump,
+            )
+        }
+    };
+
+    PickleDb::load(&path, policy_load, SerializationMethod::Bin)
+        .unwrap_or_else(|_| PickleDb::new(&path, policy_new, SerializationMethod::Bin))
+}
+
+// Check whether a filename contains any relative/path traversal characters, combine with directory if all is well
+fn validate_and_append_filename(dir: &PathBuf, filename: &str) -> Result<PathBuf, &'static str> {
+    // Check if filename contains any path separators or special directory components
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename == "."
+        || filename == ".."
+        || filename.is_empty()
+    {
+        return Err("filename contains path components");
+    }
+
+    let mut full_path = dir.clone();
+    full_path.push(filename);
+
+    // Additional safety check - verify the resulting path is actually under the original directory
+    if !full_path.starts_with(dir) {
+        return Err("path traversal attempt detected");
+    }
+
+    Ok(full_path)
+}

--- a/up-subscription/src/tests/subscription_manager_tests.rs
+++ b/up-subscription/src/tests/subscription_manager_tests.rs
@@ -45,6 +45,8 @@ mod tests {
                     test_lib::helpers::LOCAL_AUTHORITY.to_string(),
                     None,
                     None,
+                    false,
+                    None,
                 )
                 .unwrap(),
             );
@@ -76,6 +78,8 @@ mod tests {
                 USubscriptionConfiguration::create(
                     test_lib::helpers::LOCAL_AUTHORITY.to_string(),
                     None,
+                    None,
+                    false,
                     None,
                 )
                 .unwrap(),

--- a/up-subscription/src/tests/test_lib.rs
+++ b/up-subscription/src/tests/test_lib.rs
@@ -160,45 +160,42 @@ pub(crate) mod helpers {
     pub(crate) const REMOTE_AUTHORITY: &str = "REMOTE";
 
     const SUBSCRIBER1_ID: u32 = 0x0000_1000;
-    const SUBSCRIBER1_VERSION: u32 = 0x0000_0001;
-    const SUBSCRIBER1_RESOURCE: u32 = 0x000_1000;
+    const SUBSCRIBER1_VERSION: u8 = 0x01;
+    const SUBSCRIBER1_RESOURCE: u16 = 0x1000;
 
     const SUBSCRIBER2_ID: u32 = 0x0000_2000;
-    const SUBSCRIBER2_VERSION: u32 = 0x0000_0001;
-    const SUBSCRIBER2_RESOURCE: u32 = 0x0000_1000;
+    const SUBSCRIBER2_VERSION: u8 = 0x01;
+    const SUBSCRIBER2_RESOURCE: u16 = 0x1000;
 
     const SUBSCRIBER3_ID: u32 = 0x0000_3000;
-    const SUBSCRIBER3_VERSION: u32 = 0x0000_0001;
-    const SUBSCRIBER3_RESOURCE: u32 = 0x0000_1000;
+    const SUBSCRIBER3_VERSION: u8 = 0x01;
+    const SUBSCRIBER3_RESOURCE: u16 = 0x1000;
 
     #[allow(dead_code)] // final decision on removing this to happen after functional spec alignment is complete
     const NOTIFICATION_TOPIC_ID: u32 = 0x001_0000;
     #[allow(dead_code)] // final decision on removing this to happen after functional spec alignment is complete
-    const NOTIFICATION_TOPIC_VERSION: u32 = 0x0000_0001;
+    const NOTIFICATION_TOPIC_VERSION: u8 = 0x01;
     #[allow(dead_code)] // final decision on removing this to happen after functional spec alignment is complete
-    const NOTIFICATION_TOPIC_RESOURCE: u32 = 0x0000_8001;
+    const NOTIFICATION_TOPIC_RESOURCE: u16 = 0x8001;
 
     const TOPIC_LOCAL1_ID: u32 = 0x0010_0000;
-    const TOPIC_LOCAL1_VERSION: u32 = 0x0000_0001;
-    const TOPIC_LOCAL1_RESOURCE: u32 = 0x00A9_8AC7;
+    const TOPIC_LOCAL1_VERSION: u8 = 0x01;
+    const TOPIC_LOCAL1_RESOURCE: u16 = 0x8AC7;
 
     const TOPIC_LOCAL2_ID: u32 = 0x0020_0000;
-    const TOPIC_LOCAL2_VERSION: u32 = 0x0000_0001;
-    const TOPIC_LOCAL2_RESOURCE: u32 = 0x0153_158E;
+    const TOPIC_LOCAL2_VERSION: u8 = 0x01;
+    const TOPIC_LOCAL2_RESOURCE: u16 = 0x158E;
 
     const TOPIC_REMOTE1_ID: u32 = 0x0000_5000;
-    const TOPIC_REMOTE1_VERSION: u32 = 0x0000_0001;
-    const TOPIC_REMOTE1_RESOURCE: u32 = 0x2000_0000;
-
-    #[allow(dead_code)] // final decision on removing this to happen after functional spec alignment is complete
-    pub(crate) const UENTITY_OWN_URI: &str = "/7777/1/0";
+    const TOPIC_REMOTE1_VERSION: u8 = 0x01;
+    const TOPIC_REMOTE1_RESOURCE: u16 = 0x2000;
 
     pub(crate) fn subscriber_uri1() -> UUri {
         UUri {
             authority_name: LOCAL_AUTHORITY.into(),
             ue_id: SUBSCRIBER1_ID,
-            ue_version_major: SUBSCRIBER1_VERSION,
-            resource_id: SUBSCRIBER1_RESOURCE,
+            ue_version_major: SUBSCRIBER1_VERSION as u32,
+            resource_id: SUBSCRIBER1_RESOURCE as u32,
             ..Default::default()
         }
     }
@@ -207,8 +204,8 @@ pub(crate) mod helpers {
         UUri {
             authority_name: LOCAL_AUTHORITY.into(),
             ue_id: SUBSCRIBER2_ID,
-            ue_version_major: SUBSCRIBER2_VERSION,
-            resource_id: SUBSCRIBER2_RESOURCE,
+            ue_version_major: SUBSCRIBER2_VERSION as u32,
+            resource_id: SUBSCRIBER2_RESOURCE as u32,
             ..Default::default()
         }
     }
@@ -217,8 +214,8 @@ pub(crate) mod helpers {
         UUri {
             authority_name: LOCAL_AUTHORITY.into(),
             ue_id: SUBSCRIBER3_ID,
-            ue_version_major: SUBSCRIBER3_VERSION,
-            resource_id: SUBSCRIBER3_RESOURCE,
+            ue_version_major: SUBSCRIBER3_VERSION as u32,
+            resource_id: SUBSCRIBER3_RESOURCE as u32,
             ..Default::default()
         }
     }
@@ -244,8 +241,8 @@ pub(crate) mod helpers {
         UUri {
             authority_name: LOCAL_AUTHORITY.into(),
             ue_id: NOTIFICATION_TOPIC_ID,
-            ue_version_major: NOTIFICATION_TOPIC_VERSION,
-            resource_id: NOTIFICATION_TOPIC_RESOURCE,
+            ue_version_major: NOTIFICATION_TOPIC_VERSION as u32,
+            resource_id: NOTIFICATION_TOPIC_RESOURCE as u32,
             ..Default::default()
         }
     }
@@ -254,8 +251,8 @@ pub(crate) mod helpers {
         UUri {
             authority_name: LOCAL_AUTHORITY.into(),
             ue_id: TOPIC_LOCAL1_ID,
-            ue_version_major: TOPIC_LOCAL1_VERSION,
-            resource_id: TOPIC_LOCAL1_RESOURCE,
+            ue_version_major: TOPIC_LOCAL1_VERSION as u32,
+            resource_id: TOPIC_LOCAL1_RESOURCE as u32,
             ..Default::default()
         }
     }
@@ -264,8 +261,8 @@ pub(crate) mod helpers {
         UUri {
             authority_name: LOCAL_AUTHORITY.into(),
             ue_id: TOPIC_LOCAL2_ID,
-            ue_version_major: TOPIC_LOCAL2_VERSION,
-            resource_id: TOPIC_LOCAL2_RESOURCE,
+            ue_version_major: TOPIC_LOCAL2_VERSION as u32,
+            resource_id: TOPIC_LOCAL2_RESOURCE as u32,
             ..Default::default()
         }
     }
@@ -274,8 +271,8 @@ pub(crate) mod helpers {
         UUri {
             authority_name: REMOTE_AUTHORITY.into(),
             ue_id: TOPIC_REMOTE1_ID,
-            ue_version_major: TOPIC_REMOTE1_VERSION,
-            resource_id: TOPIC_REMOTE1_RESOURCE,
+            ue_version_major: TOPIC_REMOTE1_VERSION as u32,
+            resource_id: TOPIC_REMOTE1_RESOURCE as u32,
             ..Default::default()
         }
     }


### PR DESCRIPTION
USubscription spec requires that subscription status shall be persistent across runtime sessions of subscription manager. This PR implements this requirement. 

Notes: PickleDb was chosen to have some KV persistency backend to start working with - it's likely not going to survive for too long (it is harder than expected to find a simple, non-abandoned KV persistency crate)
