### PR TITLE
Add capability to persist subscription expiry property

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This codebase is approaching beta state, mirroring progress in up-spec and up-ru
 - [x] feed back learnings and clarifications into up-spec usubscription documentation
 - [ ] implement any changes necessary to align with update/re-write of uSubscription specification
 - [ ] create a little demo application for interacting with up-subscription
+- [ ] tests for subscriber persistency
+- [ ] implement subscription expiry
 
 ## Getting Started
 

--- a/up-subscription/src/handlers/fetch_subscribers.rs
+++ b/up-subscription/src/handlers/fetch_subscribers.rs
@@ -173,7 +173,7 @@ mod tests {
 
         // create request and other required object(s)
         let subscribe_request =
-            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri());
+            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
         let request_payload = UPayload::try_from_protobuf(subscribe_request.clone()).unwrap();
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -205,7 +205,7 @@ mod tests {
 
         // create request and other required object(s)
         let subscribe_request =
-            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri());
+            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
         let request_payload = UPayload::try_from_protobuf(subscribe_request.clone()).unwrap();
 
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);

--- a/up-subscription/src/handlers/fetch_subscriptions.rs
+++ b/up-subscription/src/handlers/fetch_subscriptions.rs
@@ -224,7 +224,7 @@ mod tests {
 
         // create request and other required object(s)
         let subscribe_request =
-            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri());
+            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
         let request_payload = UPayload::try_from_protobuf(subscribe_request.clone()).unwrap();
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -256,7 +256,7 @@ mod tests {
 
         // create request and other required object(s)
         let subscribe_request =
-            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri());
+            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
         let request_payload = UPayload::try_from_protobuf(subscribe_request.clone()).unwrap();
 
         let (subscription_sender, _) = mpsc::channel::<SubscriptionEvent>(1);

--- a/up-subscription/src/handlers/unsubscribe.rs
+++ b/up-subscription/src/handlers/unsubscribe.rs
@@ -303,7 +303,7 @@ mod tests {
 
         // create request and other required object(s)
         let subscribe_request =
-            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri());
+            test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
         let request_payload = UPayload::try_from_protobuf(subscribe_request.clone()).unwrap();
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),

--- a/up-subscription/src/tests/test_lib.rs
+++ b/up-subscription/src/tests/test_lib.rs
@@ -150,9 +150,10 @@ pub(crate) mod mocks {
 // Various methods for constructing helper objects to be used in tests
 #[cfg(test)]
 pub(crate) mod helpers {
+    use protobuf::well_known_types::timestamp::Timestamp;
     use up_rust::core::usubscription::{
-        SubscriberInfo, SubscriptionRequest, UnsubscribeRequest, USUBSCRIPTION_TYPE_ID,
-        USUBSCRIPTION_VERSION_MAJOR,
+        SubscribeAttributes, SubscriberInfo, SubscriptionRequest, UnsubscribeRequest,
+        USUBSCRIPTION_TYPE_ID, USUBSCRIPTION_VERSION_MAJOR,
     };
     use up_rust::UUri;
 
@@ -277,9 +278,22 @@ pub(crate) mod helpers {
         }
     }
 
-    pub(crate) fn subscription_request(topic: UUri) -> SubscriptionRequest {
+    pub(crate) fn subscription_request(
+        topic: UUri,
+        expire_seconds: Option<u32>,
+    ) -> SubscriptionRequest {
+        let attributes = expire_seconds.map(|expire| SubscribeAttributes {
+            expire: Some(Timestamp {
+                seconds: expire.into(),
+                ..Default::default()
+            })
+            .into(),
+            ..Default::default()
+        });
+
         SubscriptionRequest {
             topic: Some(topic).into(),
+            attributes: attributes.into(),
             ..Default::default()
         }
     }

--- a/up-subscription/src/usubscription.rs
+++ b/up-subscription/src/usubscription.rs
@@ -51,6 +51,9 @@ pub const INCLUDE_SCHEMA: bool = false;
 // Remote-subscribe operation ttl; 5 minutes in milliseconds, as per https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l3/usubscription/v3#6-timeout--retry-logic
 pub(crate) const UP_REMOTE_TTL: u32 = 300000;
 
+// Centralized definition, make it easier to accomodate potential changes to expiry type in up-spec
+pub(crate) type ExpiryTimestamp = u128;
+
 /// This trait primarily serves to provide a hook-point for using the mockall crate, for mocking USubscriptionService objects
 /// where we also need/want to inject custom/mock UTransport implementations that subsequently get used in test cases.
 pub trait UTransportHolder {


### PR DESCRIPTION
In preparation for implementing [subscription expiry](https://github.com/eclipse-uprotocol/up-spec/blob/aa0002d6253468bb05bfb6c6c218698b95f61f3d/up-l3/usubscription/v3/README.adoc?plain=1#L84), add capability to receive and persist subscription expiry information.