### PR TITLE
Move all notification logic to subscription_manager

### DIFF
--- a/up-subscription/src/tests/notification_manager_tests.rs
+++ b/up-subscription/src/tests/notification_manager_tests.rs
@@ -96,7 +96,7 @@ mod tests {
 
             self.command_sender
                 .send(NotificationEvent::StateChange {
-                    subscriber,
+                    subscriber: Some(subscriber),
                     topic,
                     status,
                     respond_to,


### PR DESCRIPTION
In preparation for implementing timed subscription expiry, this PR moves all subscription change notification logic to one place (`subscription_manager`). Doing this also fixes a functional gap where state-changes of remote subscriptions (e.g. from `SUBSCRIBE_PENDING` to `SUBSCRIBED`) haven't resulted in notifications at all.