### PR TITLE
Add implementation of timed subscriptions

### DIFF
--- a/up-subscription/src/common/helpers.rs
+++ b/up-subscription/src/common/helpers.rs
@@ -14,7 +14,8 @@
 use log::*;
 use std::future::Future;
 use std::sync::Once;
-use tokio::task;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::{task, time::Duration};
 
 use up_rust::{
     communication::{ServiceInvocationError, UPayload},
@@ -73,4 +74,19 @@ where
     };
 
     Ok((request, source.clone()))
+}
+
+pub(crate) fn duration_until_timestamp(future_timestamp_millis: u128) -> Option<Duration> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+
+    if future_timestamp_millis > now {
+        Some(Duration::from_millis(
+            (future_timestamp_millis - now) as u64,
+        ))
+    } else {
+        None // Timestamp is in the past
+    }
 }

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -240,26 +240,25 @@ impl SubscriptionsStore {
 
         // Extract every subscription entry that carries an expiration timestamp value
         for topic_subs in self.persistency.iter() {
-            if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<ExpiryTimestamp>>>()
-            {
-                for (subscriber, expiry) in entry {
-                    if let Some(expiry) = expiry {
-                        if helpers::duration_until_timestamp(expiry).is_some() {
-                            expiring_subscriptions.push((
-                                UUri::try_from(subscriber.clone()).map_err(|e| {
-                                    PersistencyError::serialization_error(format!(
-                                        "Error deserializing subscriber uri {e}"
-                                    ))
-                                })?,
-                                UUri::try_from(topic_subs.get_key()).map_err(|e| {
-                                    PersistencyError::serialization_error(format!(
-                                        "Error deserializing subscriber uri {e}"
-                                    ))
-                                })?,
-                                expiry,
-                            ));
-                        }
-                    }
+            if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<u128>>>() {
+                for (subscriber, expiry) in entry
+                    .iter()
+                    // filter out any entries where expiry is None
+                    .filter_map(|(subscriber, expiry)| expiry.map(|exp| (subscriber, exp)))
+                {
+                    expiring_subscriptions.push((
+                        UUri::try_from(subscriber.clone()).map_err(|e| {
+                            PersistencyError::serialization_error(format!(
+                                "Error deserializing subscriber uri {e}"
+                            ))
+                        })?,
+                        UUri::try_from(topic_subs.get_key()).map_err(|e| {
+                            PersistencyError::serialization_error(format!(
+                                "Error deserializing subscriber uri {e}"
+                            ))
+                        })?,
+                        expiry,
+                    ));
                 }
             }
         }
@@ -267,9 +266,9 @@ impl SubscriptionsStore {
         // Remove every expiration-subscription entry that has already expired from persistency
         expiring_subscriptions.retain(|(subscriber, topic, expiry)| {
             if helpers::duration_until_timestamp(*expiry).is_none() {
-                // Timestamp is in the past
+                // Timestamp expiry is in the past, so remove it from persistency,
                 let _ = self.remove_subscription(subscriber, topic);
-                false // Remove this entry from the collection
+                false // and remove this entry from the collection
             } else {
                 true // Keep this entry
             }

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -28,6 +28,10 @@ use crate::{
 // Whether to include 'up:' in serialized UUris
 const PERSIST_UP_SCHEMA: bool = true;
 
+// For better code clarity
+type SubscriberAsString = String;
+type SerializedTopicState = u8;
+
 #[allow(dead_code)] // I have no idea why clippy insists on this here - this type is most definitely being used...
 pub(crate) type SubscriptionSet =
     HashMap<TopicUUri, HashMap<SubscriberUUri, Option<ExpiryTimestamp>>>;
@@ -110,7 +114,7 @@ impl SubscriptionsStore {
         Ok(
             if let Some(mut subscriber_list) = self
                 .persistency
-                .get::<HashMap<String, Option<ExpiryTimestamp>>>(topic_string)
+                .get::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>(topic_string)
             {
                 subscriber_list.insert(subscriber_string.clone(), expiry);
                 self.persistency
@@ -151,7 +155,7 @@ impl SubscriptionsStore {
 
         if let Some(mut subscriber_list) = self
             .persistency
-            .get::<HashMap<String, Option<ExpiryTimestamp>>>(topic_string)
+            .get::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>(topic_string)
         {
             subscriber_list.remove(subscriber_string);
 
@@ -189,7 +193,7 @@ impl SubscriptionsStore {
         // the remote topic is already fully SUBSCRIBED, of still SUSBCRIBED_PENDING
         if let Some(list) = self
             .persistency
-            .get::<HashMap<String, Option<ExpiryTimestamp>>>(topic_string)
+            .get::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>(topic_string)
         {
             for entry in list.keys() {
                 subscribers.push(UUri::try_from(entry.clone()).map_err(|e| {
@@ -214,7 +218,8 @@ impl SubscriptionsStore {
         let mut result_subs: Vec<TopicUUri> = Vec::new();
 
         for entry in self.persistency.iter() {
-            if let Some(subscribers) = entry.get_value::<HashMap<String, Option<ExpiryTimestamp>>>()
+            if let Some(subscribers) =
+                entry.get_value::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>()
             {
                 if subscribers.contains_key(subscriber_string) {
                     result_subs.push(UUri::try_from(entry.get_key()).map_err(|e| {
@@ -238,7 +243,9 @@ impl SubscriptionsStore {
 
         // Extract every subscription entry that carries an expiration timestamp value
         for topic_subs in self.persistency.iter() {
-            if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<u128>>>() {
+            if let Some(entry) =
+                topic_subs.get_value::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>()
+            {
                 for (subscriber, expiry) in entry.iter() {
                     flattened_subscriptions.push((
                         UUri::try_from(subscriber.clone()).map_err(|e| {
@@ -267,7 +274,7 @@ impl SubscriptionsStore {
         &mut self,
     ) -> Result<Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)>, PersistencyError> {
         // Extract every subscription entry that carries an expiration timestamp value
-        let mut expiring_subscriptions: Vec<(UUri, UUri, u128)> = self
+        let mut expiring_subscriptions: Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)> = self
             .get_flattened_subscriptions()?
             .into_iter()
             .filter_map(|(subscriber, topic, expiry)| expiry.map(|exp| (subscriber, topic, exp)))
@@ -297,7 +304,9 @@ impl SubscriptionsStore {
             #[allow(clippy::mutable_key_type)]
             let mut topic_subscribers = HashMap::new();
 
-            if let Some(list) = entry.get_value::<HashMap<String, Option<ExpiryTimestamp>>>() {
+            if let Some(list) =
+                entry.get_value::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>()
+            {
                 for (subscriber, expiry) in list {
                     topic_subscribers.insert(
                         UUri::try_from(subscriber).map_err(|e| {
@@ -335,7 +344,7 @@ impl SubscriptionsStore {
                     &subscribers
                         .iter()
                         .map(|(u, e)| (u.to_uri(PERSIST_UP_SCHEMA), *e))
-                        .collect::<HashMap<String, Option<ExpiryTimestamp>>>(),
+                        .collect::<HashMap<SubscriberAsString, Option<ExpiryTimestamp>>>(),
                 )
                 .map_err(|e| {
                     PersistencyError::serialization_error(format!(
@@ -376,11 +385,12 @@ impl RemoteTopicsStore {
         let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
 
         Ok(if self.persistency.exists(topic_string) {
-            let bytes = self.persistency.get::<Vec<u8>>(topic_string).ok_or(
-                PersistencyError::internal_error(
+            let bytes = self
+                .persistency
+                .get::<Vec<SerializedTopicState>>(topic_string)
+                .ok_or(PersistencyError::internal_error(
                     "Error retrieving remote topic state from persistency",
-                ),
-            )?;
+                ))?;
             Some(deserialize_topic_state(&bytes).map_err(|e| {
                 PersistencyError::serialization_error(format!(
                     "Error deserializing topic state {e}"
@@ -424,11 +434,12 @@ impl RemoteTopicsStore {
 
         // if remote topic already has been registered, retrieve state
         Ok(if self.persistency.exists(topic_string) {
-            let bytes = self.persistency.get::<Vec<u8>>(topic_string).ok_or(
-                PersistencyError::internal_error(
+            let bytes = self
+                .persistency
+                .get::<Vec<SerializedTopicState>>(topic_string)
+                .ok_or(PersistencyError::internal_error(
                     "Error retrieving remote topic state from persistency",
-                ),
-            )?;
+                ))?;
             deserialize_topic_state(&bytes).map_err(|e| {
                 PersistencyError::serialization_error(format!(
                     "Error deserializing topic state {e}"
@@ -447,7 +458,7 @@ impl RemoteTopicsStore {
         let mut map: HashMap<TopicUUri, TopicState> = HashMap::new();
 
         for kv in self.persistency.iter() {
-            if let Some(bytes) = kv.get_value::<Vec<u8>>() {
+            if let Some(bytes) = kv.get_value::<Vec<SerializedTopicState>>() {
                 let value = deserialize_topic_state(&bytes)?;
                 map.insert(UUri::try_from(kv.get_key())?, value);
             }
@@ -536,7 +547,7 @@ impl NotificationStore {
         let mut result = vec![];
 
         for entry in self.persistency.iter() {
-            if let Some(bytes) = entry.get_value::<Vec<u8>>() {
+            if let Some(bytes) = entry.get_value::<Vec<SerializedTopicState>>() {
                 let topic = deserialize_uuri(&bytes).map_err(|e| {
                     PersistencyError::serialization_error(format!(
                         "Error deserializing notification topic {e}"
@@ -556,7 +567,7 @@ impl NotificationStore {
         let mut map: HashMap<SubscriberUUri, TopicUUri> = HashMap::new();
 
         for kv in self.persistency.iter() {
-            if let Some(bytes) = kv.get_value::<Vec<u8>>() {
+            if let Some(bytes) = kv.get_value::<Vec<SerializedTopicState>>() {
                 let value = deserialize_uuri(&bytes)?;
                 map.insert(UUri::try_from(kv.get_key())?, value);
             }
@@ -589,11 +600,15 @@ fn deserialize_uuri(bytes: &[u8]) -> Result<UUri, Box<dyn std::error::Error>> {
     Ok(UUri::parse_from_bytes(bytes)?)
 }
 
-fn serialize_topic_state(state: &TopicState) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+fn serialize_topic_state(
+    state: &TopicState,
+) -> Result<Vec<SerializedTopicState>, Box<dyn std::error::Error>> {
     Ok(state.value().to_le_bytes().to_vec())
 }
 
-fn deserialize_topic_state(bytes: &[u8]) -> Result<TopicState, Box<dyn std::error::Error>> {
+fn deserialize_topic_state(
+    bytes: &[SerializedTopicState],
+) -> Result<TopicState, Box<dyn std::error::Error>> {
     Ok(
         TopicState::from_i32(i32::from_le_bytes(bytes[..4].try_into()?))
             .ok_or_else(|| serde::de::value::Error::custom("Invalid TopicState value"))?,

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -19,15 +19,18 @@ use std::{convert::TryInto, path::PathBuf};
 
 use up_rust::{core::usubscription::State as TopicState, UUri};
 
-use crate::{helpers, usubscription, USubscriptionConfiguration};
+use crate::{
+    helpers,
+    usubscription::{ExpiryTimestamp, SubscriberUUri, TopicUUri},
+    USubscriptionConfiguration,
+};
 
 // Whether to include 'up:' in serialized UUris
 const PERSIST_UP_SCHEMA: bool = true;
 
-// Semantic structure of this: HashMap<Topic, HashMap<Subscriber, Option<Expiry>>
 #[allow(dead_code)] // I have no idea why clippy insists on this here - this type is most definitely being used...
 pub(crate) type SubscriptionSet =
-    HashMap<UUri, HashMap<UUri, Option<usubscription::ExpiryTimestamp>>>;
+    HashMap<TopicUUri, HashMap<SubscriberUUri, Option<ExpiryTimestamp>>>;
 
 #[derive(Debug)]
 pub(crate) enum PersistencyError {
@@ -96,9 +99,9 @@ impl SubscriptionsStore {
     /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
     pub(crate) fn add_subscription(
         &mut self,
-        subscriber: &UUri,
-        topic: &UUri,
-        expiry: Option<usubscription::ExpiryTimestamp>,
+        subscriber: &SubscriberUUri,
+        topic: &TopicUUri,
+        expiry: Option<ExpiryTimestamp>,
     ) -> Result<bool, PersistencyError> {
         // serialize inputs to types used in persistency
         let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
@@ -107,7 +110,7 @@ impl SubscriptionsStore {
         Ok(
             if let Some(mut subscriber_list) = self
                 .persistency
-                .get::<HashMap<String, Option<usubscription::ExpiryTimestamp>>>(topic_string)
+                .get::<HashMap<String, Option<ExpiryTimestamp>>>(topic_string)
             {
                 subscriber_list.insert(subscriber_string.clone(), expiry);
                 self.persistency
@@ -139,8 +142,8 @@ impl SubscriptionsStore {
     /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
     pub(crate) fn remove_subscription(
         &mut self,
-        subscriber: &UUri,
-        topic: &UUri,
+        subscriber: &SubscriberUUri,
+        topic: &TopicUUri,
     ) -> Result<bool, PersistencyError> {
         // serialize inputs to types used in persistency
         let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
@@ -173,12 +176,12 @@ impl SubscriptionsStore {
     }
 
     /// Return a list of all subscribers of given topic
-    /// * returns `Vec<UUri>` that contains all subscriber UUris registered for the topic
+    /// * returns `Vec<SubscriberUUri>` that contains all subscriber UUris registered for the topic
     /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
     pub(crate) fn get_topic_subscribers(
         &self,
-        topic: &UUri,
-    ) -> Result<Vec<UUri>, PersistencyError> {
+        topic: &TopicUUri,
+    ) -> Result<Vec<SubscriberUUri>, PersistencyError> {
         let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
         let mut subscribers = vec![];
 
@@ -201,14 +204,14 @@ impl SubscriptionsStore {
     }
 
     /// Return a list of all topics subscribed to by given subscriber
-    /// * returns `Vec<UUri>` that contains all topics subscribed to by subscriber
+    /// * returns `Vec<TopicUUri>` that contains all topics subscribed to by subscriber
     /// * returns a `PersistencyError` in case of problems with serialization of data or manipulation of persist storage
     pub(crate) fn get_subscriber_topics(
         &self,
-        subscriber: &UUri,
-    ) -> Result<Vec<UUri>, PersistencyError> {
+        subscriber: &SubscriberUUri,
+    ) -> Result<Vec<TopicUUri>, PersistencyError> {
         let subscriber_string = &subscriber.to_uri(PERSIST_UP_SCHEMA);
-        let mut result_subs: Vec<UUri> = Vec::new();
+        let mut result_subs: Vec<TopicUUri> = Vec::new();
 
         for entry in self.persistency.iter() {
             if let Some(subscribers) = entry.get_value::<HashMap<String, Option<u128>>>() {
@@ -230,8 +233,8 @@ impl SubscriptionsStore {
     /// - return all remaining subscription relationships which have an expiration timestamp that has not yet expired
     pub(crate) fn get_and_prune_expiring_subscriptions(
         &mut self,
-    ) -> Result<Vec<(UUri, UUri, u128)>, PersistencyError> {
-        let mut expiring_subscriptions: Vec<(UUri, UUri, u128)> = Vec::new();
+    ) -> Result<Vec<(SubscriberUUri, TopicUUri, u128)>, PersistencyError> {
+        let mut expiring_subscriptions: Vec<(SubscriberUUri, TopicUUri, u128)> = Vec::new();
 
         // Extract every subscription entry that carries an expiration timestamp value
         for topic_subs in self.persistency.iter() {
@@ -282,9 +285,7 @@ impl SubscriptionsStore {
             #[allow(clippy::mutable_key_type)]
             let mut topic_subscribers = HashMap::new();
 
-            if let Some(list) =
-                entry.get_value::<HashMap<String, Option<usubscription::ExpiryTimestamp>>>()
-            {
+            if let Some(list) = entry.get_value::<HashMap<String, Option<ExpiryTimestamp>>>() {
                 for (subscriber, expiry) in list {
                     topic_subscribers.insert(
                         UUri::try_from(subscriber).map_err(|e| {
@@ -322,7 +323,7 @@ impl SubscriptionsStore {
                     &subscribers
                         .iter()
                         .map(|(u, e)| (u.to_uri(PERSIST_UP_SCHEMA), *e))
-                        .collect::<HashMap<String, Option<usubscription::ExpiryTimestamp>>>(),
+                        .collect::<HashMap<String, Option<ExpiryTimestamp>>>(),
                 )
                 .map_err(|e| {
                     PersistencyError::serialization_error(format!(
@@ -358,7 +359,7 @@ impl RemoteTopicsStore {
     /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
     pub(crate) fn get_topic_state(
         &self,
-        topic: &UUri,
+        topic: &TopicUUri,
     ) -> Result<Option<TopicState>, PersistencyError> {
         let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
 
@@ -383,7 +384,7 @@ impl RemoteTopicsStore {
     /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
     pub(crate) fn set_topic_state(
         &mut self,
-        topic: &UUri,
+        topic: &TopicUUri,
         state: TopicState,
     ) -> Result<TopicState, PersistencyError> {
         let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
@@ -405,7 +406,7 @@ impl RemoteTopicsStore {
     /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
     pub(crate) fn add_topic_or_get_state(
         &mut self,
-        topic: &UUri,
+        topic: &TopicUUri,
     ) -> Result<TopicState, PersistencyError> {
         let topic_string = &topic.to_uri(Self::PERSIST_UP_SCHEMA);
 
@@ -427,9 +428,11 @@ impl RemoteTopicsStore {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_data(&self) -> Result<HashMap<UUri, TopicState>, Box<dyn std::error::Error>> {
+    pub(crate) fn get_data(
+        &self,
+    ) -> Result<HashMap<TopicUUri, TopicState>, Box<dyn std::error::Error>> {
         #[allow(clippy::mutable_key_type)]
-        let mut map: HashMap<UUri, TopicState> = HashMap::new();
+        let mut map: HashMap<TopicUUri, TopicState> = HashMap::new();
 
         for kv in self.persistency.iter() {
             if let Some(bytes) = kv.get_value::<Vec<u8>>() {
@@ -445,7 +448,7 @@ impl RemoteTopicsStore {
     #[allow(clippy::mutable_key_type)]
     pub(crate) fn set_data(
         &mut self,
-        map: HashMap<UUri, TopicState>,
+        map: HashMap<TopicUUri, TopicState>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         for (key, value) in map {
             let _r = self.persistency.set(
@@ -480,8 +483,8 @@ impl NotificationStore {
     /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
     pub(crate) fn add_notifyee(
         &mut self,
-        subscriber: &UUri,
-        topic: &UUri,
+        subscriber: &SubscriberUUri,
+        topic: &TopicUUri,
     ) -> Result<(), PersistencyError> {
         let subscriber_string = subscriber.to_uri(Self::PERSIST_UP_SCHEMA);
         let topic_bytes = serialize_uuri(topic)
@@ -499,7 +502,10 @@ impl NotificationStore {
     /// Remove subscriber from custom-notifications store
     /// * return `Ok(())` on success
     /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
-    pub(crate) fn remove_notifyee(&mut self, subscriber: &UUri) -> Result<(), PersistencyError> {
+    pub(crate) fn remove_notifyee(
+        &mut self,
+        subscriber: &SubscriberUUri,
+    ) -> Result<(), PersistencyError> {
         self.persistency
             .rem(&subscriber.to_uri(Self::PERSIST_UP_SCHEMA))
             .map_err(|e| {
@@ -512,9 +518,9 @@ impl NotificationStore {
     }
 
     /// Get a list of all topic keys from custom notification persistency
-    /// * return a `Vec<UUri>` list of topic UUris
+    /// * return a `Vec<TopicUUri>` list of topic UUris
     /// * returns a `PersistencyError` in case something went wrong with data serialization or storage
-    pub(crate) fn get_topics(&mut self) -> Result<Vec<UUri>, PersistencyError> {
+    pub(crate) fn get_topics(&mut self) -> Result<Vec<TopicUUri>, PersistencyError> {
         let mut result = vec![];
 
         for entry in self.persistency.iter() {
@@ -531,9 +537,11 @@ impl NotificationStore {
     }
 
     #[cfg(test)]
-    pub(crate) fn get_data(&self) -> Result<HashMap<UUri, UUri>, Box<dyn std::error::Error>> {
+    pub(crate) fn get_data(
+        &self,
+    ) -> Result<HashMap<SubscriberUUri, TopicUUri>, Box<dyn std::error::Error>> {
         #[allow(clippy::mutable_key_type)]
-        let mut map: HashMap<UUri, UUri> = HashMap::new();
+        let mut map: HashMap<SubscriberUUri, TopicUUri> = HashMap::new();
 
         for kv in self.persistency.iter() {
             if let Some(bytes) = kv.get_value::<Vec<u8>>() {
@@ -549,7 +557,7 @@ impl NotificationStore {
     #[allow(clippy::mutable_key_type)]
     pub(crate) fn set_data(
         &mut self,
-        map: HashMap<UUri, UUri>,
+        map: HashMap<SubscriberUUri, TopicUUri>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         for (key, value) in map {
             let _r = self

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -104,8 +104,8 @@ impl SubscriptionsStore {
         expiry: Option<ExpiryTimestamp>,
     ) -> Result<bool, PersistencyError> {
         // serialize inputs to types used in persistency
-        let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
         let subscriber_string = &subscriber.to_uri(PERSIST_UP_SCHEMA);
+        let topic_string = &topic.to_uri(PERSIST_UP_SCHEMA);
 
         Ok(
             if let Some(mut subscriber_list) = self
@@ -229,24 +229,18 @@ impl SubscriptionsStore {
         Ok(result_subs)
     }
 
-    /// This function does two things
-    /// - remove any subscription relationships from persistency that have an expiration timestamp that lies in the past
-    /// - return all remaining subscription relationships which have an expiration timestamp that has not yet expired
-    pub(crate) fn get_and_prune_expiring_subscriptions(
+    // Return a flattened list of all subscriptions stored in persistency
+    pub(crate) fn get_flattened_subscriptions(
         &mut self,
-    ) -> Result<Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)>, PersistencyError> {
-        let mut expiring_subscriptions: Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)> =
+    ) -> Result<Vec<(SubscriberUUri, TopicUUri, Option<ExpiryTimestamp>)>, PersistencyError> {
+        let mut flattened_subscriptions: Vec<(SubscriberUUri, TopicUUri, Option<ExpiryTimestamp>)> =
             Vec::new();
 
         // Extract every subscription entry that carries an expiration timestamp value
         for topic_subs in self.persistency.iter() {
             if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<u128>>>() {
-                for (subscriber, expiry) in entry
-                    .iter()
-                    // filter out any entries where expiry is None
-                    .filter_map(|(subscriber, expiry)| expiry.map(|exp| (subscriber, exp)))
-                {
-                    expiring_subscriptions.push((
+                for (subscriber, expiry) in entry.iter() {
+                    flattened_subscriptions.push((
                         UUri::try_from(subscriber.clone()).map_err(|e| {
                             PersistencyError::serialization_error(format!(
                                 "Error deserializing subscriber uri {e}"
@@ -257,11 +251,27 @@ impl SubscriptionsStore {
                                 "Error deserializing subscriber uri {e}"
                             ))
                         })?,
-                        expiry,
+                        *expiry,
                     ));
                 }
             }
         }
+
+        Ok(flattened_subscriptions)
+    }
+
+    /// This function does two things
+    /// - remove any subscription relationships from persistency that have an expiration timestamp that lies in the past
+    /// - return all remaining subscription relationships which have an expiration timestamp that has not yet expired
+    pub(crate) fn get_and_prune_expiring_subscriptions(
+        &mut self,
+    ) -> Result<Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)>, PersistencyError> {
+        // Extract every subscription entry that carries an expiration timestamp value
+        let mut expiring_subscriptions: Vec<(UUri, UUri, u128)> = self
+            .get_flattened_subscriptions()?
+            .into_iter()
+            .filter_map(|(subscriber, topic, expiry)| expiry.map(|exp| (subscriber, topic, exp)))
+            .collect();
 
         // Remove every expiration-subscription entry that has already expired from persistency
         expiring_subscriptions.retain(|(subscriber, topic, expiry)| {

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -19,11 +19,12 @@ use std::{convert::TryInto, path::PathBuf};
 
 use up_rust::{core::usubscription::State as TopicState, UUri};
 
-use crate::{usubscription, USubscriptionConfiguration};
+use crate::{helpers, usubscription, USubscriptionConfiguration};
 
 // Whether to include 'up:' in serialized UUris
 const PERSIST_UP_SCHEMA: bool = true;
 
+// Semantic structure of this: HashMap<Topic, HashMap<Subscriber, Option<Expiry>>
 #[allow(dead_code)] // I have no idea why clippy insists on this here - this type is most definitely being used...
 pub(crate) type SubscriptionSet =
     HashMap<UUri, HashMap<UUri, Option<usubscription::ExpiryTimestamp>>>;
@@ -147,7 +148,7 @@ impl SubscriptionsStore {
 
         if let Some(mut subscriber_list) = self
             .persistency
-            .get::<HashMap<String, Option<u32>>>(topic_string)
+            .get::<HashMap<String, Option<u128>>>(topic_string)
         {
             subscriber_list.remove(subscriber_string);
 
@@ -185,7 +186,7 @@ impl SubscriptionsStore {
         // the remote topic is already fully SUBSCRIBED, of still SUSBCRIBED_PENDING
         if let Some(list) = self
             .persistency
-            .get::<HashMap<String, Option<u32>>>(topic_string)
+            .get::<HashMap<String, Option<u128>>>(topic_string)
         {
             for entry in list.keys() {
                 subscribers.push(UUri::try_from(entry.clone()).map_err(|e| {
@@ -210,7 +211,7 @@ impl SubscriptionsStore {
         let mut result_subs: Vec<UUri> = Vec::new();
 
         for entry in self.persistency.iter() {
-            if let Some(subscribers) = entry.get_value::<HashMap<String, Option<u32>>>() {
+            if let Some(subscribers) = entry.get_value::<HashMap<String, Option<u128>>>() {
                 if subscribers.contains_key(subscriber_string) {
                     result_subs.push(UUri::try_from(entry.get_key()).map_err(|e| {
                         PersistencyError::serialization_error(format!(
@@ -222,6 +223,54 @@ impl SubscriptionsStore {
         }
 
         Ok(result_subs)
+    }
+
+    /// This function does two things
+    /// - remove any subscription relationships from persistency that have an expiration timestamp that lies in the past
+    /// - return all remaining subscription relationships which have an expiration timestamp that has not yet expired
+    pub(crate) fn get_and_prune_expiring_subscriptions(
+        &mut self,
+    ) -> Result<Vec<(UUri, UUri, u128)>, PersistencyError> {
+        let mut expiring_subscriptions: Vec<(UUri, UUri, u128)> = Vec::new();
+
+        // Extract every subscription entry that carries an expiration timestamp value
+        for topic_subs in self.persistency.iter() {
+            if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<u128>>>() {
+                for (subscriber, expiry) in entry {
+                    if let Some(expiry) = expiry {
+                        if helpers::duration_until_timestamp(expiry).is_some() {
+                            expiring_subscriptions.push((
+                                UUri::try_from(subscriber.clone()).map_err(|e| {
+                                    PersistencyError::serialization_error(format!(
+                                        "Error deserializing subscriber uri {e}"
+                                    ))
+                                })?,
+                                UUri::try_from(topic_subs.get_key()).map_err(|e| {
+                                    PersistencyError::serialization_error(format!(
+                                        "Error deserializing subscriber uri {e}"
+                                    ))
+                                })?,
+                                expiry,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Remove every expiration-subscription entry that has already expired from persistency
+        expiring_subscriptions.retain(|(subscriber, topic, expiry)| {
+            if helpers::duration_until_timestamp(*expiry).is_none() {
+                // Timestamp is in the past
+                let _ = self.remove_subscription(subscriber, topic);
+                false // Remove this entry from the collection
+            } else {
+                true // Keep this entry
+            }
+        });
+
+        // return remaining subscription entries (all entries with expiration timestamp in the future)
+        Ok(expiring_subscriptions)
     }
 
     #[cfg(test)]

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -151,7 +151,7 @@ impl SubscriptionsStore {
 
         if let Some(mut subscriber_list) = self
             .persistency
-            .get::<HashMap<String, Option<u128>>>(topic_string)
+            .get::<HashMap<String, Option<ExpiryTimestamp>>>(topic_string)
         {
             subscriber_list.remove(subscriber_string);
 
@@ -189,7 +189,7 @@ impl SubscriptionsStore {
         // the remote topic is already fully SUBSCRIBED, of still SUSBCRIBED_PENDING
         if let Some(list) = self
             .persistency
-            .get::<HashMap<String, Option<u128>>>(topic_string)
+            .get::<HashMap<String, Option<ExpiryTimestamp>>>(topic_string)
         {
             for entry in list.keys() {
                 subscribers.push(UUri::try_from(entry.clone()).map_err(|e| {
@@ -214,7 +214,8 @@ impl SubscriptionsStore {
         let mut result_subs: Vec<TopicUUri> = Vec::new();
 
         for entry in self.persistency.iter() {
-            if let Some(subscribers) = entry.get_value::<HashMap<String, Option<u128>>>() {
+            if let Some(subscribers) = entry.get_value::<HashMap<String, Option<ExpiryTimestamp>>>()
+            {
                 if subscribers.contains_key(subscriber_string) {
                     result_subs.push(UUri::try_from(entry.get_key()).map_err(|e| {
                         PersistencyError::serialization_error(format!(
@@ -233,12 +234,14 @@ impl SubscriptionsStore {
     /// - return all remaining subscription relationships which have an expiration timestamp that has not yet expired
     pub(crate) fn get_and_prune_expiring_subscriptions(
         &mut self,
-    ) -> Result<Vec<(SubscriberUUri, TopicUUri, u128)>, PersistencyError> {
-        let mut expiring_subscriptions: Vec<(SubscriberUUri, TopicUUri, u128)> = Vec::new();
+    ) -> Result<Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)>, PersistencyError> {
+        let mut expiring_subscriptions: Vec<(SubscriberUUri, TopicUUri, ExpiryTimestamp)> =
+            Vec::new();
 
         // Extract every subscription entry that carries an expiration timestamp value
         for topic_subs in self.persistency.iter() {
-            if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<u128>>>() {
+            if let Some(entry) = topic_subs.get_value::<HashMap<String, Option<ExpiryTimestamp>>>()
+            {
                 for (subscriber, expiry) in entry {
                     if let Some(expiry) = expiry {
                         if helpers::duration_until_timestamp(expiry).is_some() {

--- a/up-subscription/src/subscription_manager.rs
+++ b/up-subscription/src/subscription_manager.rs
@@ -15,10 +15,10 @@ use log::*;
 #[cfg(test)]
 use std::collections::HashMap;
 use std::sync::Arc;
-#[cfg(test)]
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::{mpsc, mpsc::Receiver, mpsc::Sender, oneshot, Notify};
-use up_rust::{LocalUriProvider, UTransport};
+use tokio::{
+    sync::{mpsc, mpsc::Receiver, mpsc::Sender, oneshot, Notify},
+    time::sleep,
+};
 
 use up_rust::{
     communication::{CallOptions, InMemoryRpcClient, RpcClient},
@@ -27,7 +27,7 @@ use up_rust::{
         UnsubscribeRequest, RESOURCE_ID_SUBSCRIBE, RESOURCE_ID_UNSUBSCRIBE, USUBSCRIPTION_TYPE_ID,
         USUBSCRIPTION_VERSION_MAJOR,
     },
-    UCode, UPriority, UStatus, UUri,
+    LocalUriProvider, UCode, UPriority, UStatus, UTransport, UUri,
 };
 
 use crate::{
@@ -44,6 +44,8 @@ use crate::{
 const UP_MAX_FETCH_SUBSCRIBERS_LEN: usize = 100;
 // Maximum number of `Subscriber` entries to be returned in a `FetchSusbcriptions´ operation
 const UP_MAX_FETCH_SUBSCRIPTIONS_LEN: usize = 100;
+
+const INTERNAL_COMMAND_BUFFER_SIZE: usize = 128;
 
 #[derive(Debug)]
 pub(crate) enum RequestKind {
@@ -110,20 +112,21 @@ pub(crate) enum SubscriptionEvent {
     // Purely for use during testing: get internal remote-subscription-change command sender
     #[cfg(test)]
     GetRemoteSubscriptionChangeSender {
-        respond_to: oneshot::Sender<UnboundedSender<RemoteSubscriptionEvent>>,
+        respond_to: oneshot::Sender<Sender<InternalSubscriptionEvent>>,
     },
 }
 
 // Internal subscription manager API - used to update on remote subscriptions (deal with _PENDING states)
 #[derive(Debug)]
-pub(crate) enum RemoteSubscriptionEvent {
-    RemoteTopicStateUpdate { topic: UUri, state: TopicState },
+pub(crate) enum InternalSubscriptionEvent {
+    TopicStateUpdate { topic: UUri, state: TopicState },
+    RemoveExpiredSubscription { subscriber: UUri, topic: UUri },
 }
 
 // Wrapper type, include all kinds of actions subscription manager knows
 enum Event {
     LocalSubscription(SubscriptionEvent),
-    RemoteSubscription(RemoteSubscriptionEvent),
+    RemoteSubscription(InternalSubscriptionEvent),
 }
 
 // Core business logic of subscription management - includes container data types for tracking subscriptions and remote subscriptions.
@@ -144,8 +147,25 @@ pub(crate) async fn handle_message(
     // for remote topics, we need to additionally deal with _PENDING states, this tracks states of these topics
     let mut remote_topics = persistency::RemoteTopicsStore::new(&configuration);
 
-    let (remote_sub_sender, mut remote_sub_receiver) =
-        mpsc::unbounded_channel::<RemoteSubscriptionEvent>();
+    let (internal_cmd_sender, mut internal_cmd_receiver) =
+        mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
+
+    // At startup, set up timed unsubscribe for any persisted subscriptions that define an expiration timestamp
+    match subscriptions.get_and_prune_expiring_subscriptions() {
+        Ok(list) => {
+            for (subscriber, topic, expiry_millis) in list {
+                schedule_unsubscribe(
+                    expiry_millis,
+                    subscriber.clone(),
+                    topic.clone(),
+                    internal_cmd_sender.clone(),
+                );
+            }
+        }
+        Err(e) => {
+            panic!("Persistency failure {e}")
+        }
+    };
 
     loop {
         let event: Event = tokio::select! {
@@ -158,7 +178,7 @@ pub(crate) async fn handle_message(
                 Some(event) => Event::LocalSubscription(event),
             },
             // "Inside" events - updates around remote subscription states
-            event = remote_sub_receiver.recv() => match event {
+            event = internal_cmd_receiver.recv() => match event {
                 None => {
                     error!("Problem with subscription command channel, received None-event");
                     break
@@ -179,7 +199,7 @@ pub(crate) async fn handle_message(
                     match add_subscription(
                         configuration.clone(),
                         transport.clone(),
-                        remote_sub_sender.clone(),
+                        internal_cmd_sender.clone(),
                         &mut subscriptions,
                         &mut remote_topics,
                         subscriber.clone(),
@@ -190,8 +210,8 @@ pub(crate) async fn handle_message(
                             // Send topic state change notification
                             notification_manager::notify(
                                 notification_sender.clone(),
-                                Some(subscriber),
-                                topic,
+                                Some(subscriber.clone()),
+                                topic.clone(),
                                 result.clone(),
                             )
                             .await;
@@ -213,7 +233,7 @@ pub(crate) async fn handle_message(
                     match remove_subscription(
                         configuration.clone(),
                         transport.clone(),
-                        remote_sub_sender.clone(),
+                        internal_cmd_sender.clone(),
                         &mut subscriptions,
                         &mut remote_topics,
                         subscriber.clone(),
@@ -314,14 +334,16 @@ pub(crate) async fn handle_message(
                 },
                 #[cfg(test)]
                 SubscriptionEvent::GetRemoteSubscriptionChangeSender { respond_to } => {
-                    let _ = respond_to.send(remote_sub_sender.clone());
+                    let _ = respond_to.send(internal_cmd_sender.clone());
                 }
             },
             // deal with feedback/state updates from the remote subscription handlers
             Event::RemoteSubscription(event) => match event {
-                RemoteSubscriptionEvent::RemoteTopicStateUpdate { topic, state } => {
+                InternalSubscriptionEvent::TopicStateUpdate { topic, state } => {
                     match remote_topics.set_topic_state(&topic, state) {
                         Ok(_) => {
+                            // Set up timed unsubscription here, in case state changes to ::PENDING
+
                             // Send topic state change notification - in the case of remote subscriptions,
                             // the subscriber is usubscription service itself, so leave that field empty.
                             notification_manager::notify(
@@ -340,6 +362,32 @@ pub(crate) async fn handle_message(
                         }
                     }
                 }
+                // Remote expired subscriptions, via internal command channel
+                InternalSubscriptionEvent::RemoveExpiredSubscription { subscriber, topic } => {
+                    match remove_subscription(
+                        configuration.clone(),
+                        transport.clone(),
+                        internal_cmd_sender.clone(),
+                        &mut subscriptions,
+                        &mut remote_topics,
+                        subscriber.clone(),
+                        topic.clone(),
+                    ) {
+                        Ok(result) => {
+                            // Send topic state change notification
+                            notification_manager::notify(
+                                notification_sender.clone(),
+                                Some(subscriber),
+                                topic,
+                                result.clone(),
+                            )
+                            .await;
+                        }
+                        Err(e) => {
+                            panic!("Persistency failure {e}")
+                        }
+                    }
+                }
             },
         }
     }
@@ -350,7 +398,7 @@ pub(crate) async fn handle_message(
 fn add_subscription(
     uri_provider: Arc<dyn LocalUriProvider>,
     transport: Arc<dyn UTransport>,
-    remote_sub_sender: mpsc::UnboundedSender<RemoteSubscriptionEvent>,
+    internal_cmd_sender: Sender<InternalSubscriptionEvent>,
     topic_subscribers: &mut persistency::SubscriptionsStore,
     remote_topics: &mut persistency::RemoteTopicsStore,
     subscriber: UUri,
@@ -359,22 +407,41 @@ fn add_subscription(
 ) -> Result<SubscriptionStatus, persistency::PersistencyError> {
     let _ = topic_subscribers.add_subscription(&subscriber, &topic, expiry)?;
 
-    // for remote_topics, we explicitly track state due to _PENDING scenarios
+    // For REMOTE topics, we explicitly track state due to _PENDING scenarios
     let state = if topic.is_remote_authority(&uri_provider.get_authority()) {
         let state = remote_topics.add_topic_or_get_state(&topic)?;
 
         // if this remote topic is not yet SUBSCRIBED, perform remote subscription
         if state != TopicState::SUBSCRIBED {
+            let topic_clone = topic.clone();
+            let internal_cmd_sender_clone = internal_cmd_sender.clone();
             helpers::spawn_and_log_error(async move {
-                remote_subscribe(topic, uri_provider, transport, remote_sub_sender).await?;
+                remote_subscribe(
+                    topic_clone,
+                    uri_provider,
+                    transport,
+                    internal_cmd_sender_clone,
+                )
+                .await?;
                 Ok(())
             });
         }
         state
     } else {
-        // Local topics are considered to have status SUBSCRIBED as soon as they are registered here
+        // Otherwise, LOCAL topics are considered to have status SUBSCRIBED as soon as they are registered here
         TopicState::SUBSCRIBED
     };
+
+    // Set up timed unsubscribe in case expiration timestamp is set
+    if let Some(expiry_millis) = expiry {
+        schedule_unsubscribe(
+            expiry_millis,
+            subscriber.clone(),
+            topic,
+            internal_cmd_sender,
+        );
+    };
+
     Ok(SubscriptionStatus {
         state: state.into(),
         ..Default::default()
@@ -385,7 +452,7 @@ fn add_subscription(
 fn remove_subscription(
     uri_provider: Arc<dyn LocalUriProvider>,
     transport: Arc<dyn UTransport>,
-    remote_sub_sender: mpsc::UnboundedSender<RemoteSubscriptionEvent>,
+    internal_cmd_sender: Sender<InternalSubscriptionEvent>,
     topic_subscribers: &mut persistency::SubscriptionsStore,
     remote_topics: &mut persistency::RemoteTopicsStore,
     subscriber: UUri,
@@ -400,7 +467,7 @@ fn remove_subscription(
 
         // perform remote unsubscription
         helpers::spawn_and_log_error(async move {
-            remote_unsubscribe(topic, uri_provider, transport, remote_sub_sender).await?;
+            remote_unsubscribe(topic, uri_provider, transport, internal_cmd_sender).await?;
             Ok(())
         });
     }
@@ -499,7 +566,7 @@ async fn remote_subscribe(
     topic: UUri,
     uri_provider: Arc<dyn LocalUriProvider>,
     transport: Arc<dyn UTransport>,
-    remote_sub_sender: mpsc::UnboundedSender<RemoteSubscriptionEvent>,
+    internal_cmd_sender: Sender<InternalSubscriptionEvent>,
 ) -> Result<(), UStatus> {
     let rpc_client: Arc<dyn RpcClient> = Arc::new(
         InMemoryRpcClient::new(transport, uri_provider)
@@ -537,10 +604,12 @@ async fn remote_subscribe(
     if subscription_response.is_state(TopicState::SUBSCRIBED) {
         debug!("Got remote subscription response, state SUBSCRIBED");
 
-        let _ = remote_sub_sender.send(RemoteSubscriptionEvent::RemoteTopicStateUpdate {
-            topic,
-            state: TopicState::SUBSCRIBED,
-        });
+        let _ = internal_cmd_sender
+            .send(InternalSubscriptionEvent::TopicStateUpdate {
+                topic,
+                state: TopicState::SUBSCRIBED,
+            })
+            .await;
     } else {
         debug!("Got remote subscription response, some other state");
     }
@@ -553,7 +622,7 @@ async fn remote_unsubscribe(
     topic: UUri,
     uri_provider: Arc<dyn LocalUriProvider>,
     transport: Arc<dyn UTransport>,
-    remote_sub_sender: mpsc::UnboundedSender<RemoteSubscriptionEvent>,
+    internal_cmd_sender: Sender<InternalSubscriptionEvent>,
 ) -> Result<(), UStatus> {
     let rpc_client: Arc<dyn RpcClient> = Arc::new(
         InMemoryRpcClient::new(transport, uri_provider)
@@ -591,10 +660,12 @@ async fn remote_unsubscribe(
     match unsubscribe_response.code.enum_value_or(UCode::UNKNOWN) {
         UCode::OK => {
             debug!("Got OK remote unsubscribe response");
-            let _ = remote_sub_sender.send(RemoteSubscriptionEvent::RemoteTopicStateUpdate {
-                topic,
-                state: TopicState::UNSUBSCRIBED,
-            });
+            let _ = internal_cmd_sender
+                .send(InternalSubscriptionEvent::TopicStateUpdate {
+                    topic,
+                    state: TopicState::UNSUBSCRIBED,
+                })
+                .await;
         }
         code => {
             debug!("Got {:?} remote unsubscribe response", code);
@@ -606,6 +677,27 @@ async fn remote_unsubscribe(
     };
 
     Ok(())
+}
+
+// Internal helper that will spawn a task to unsubscribe a subscriber-topic relationship at timestamp `expiry`.
+// In case the expiry timestamp is already in the past, unsubscribe will be initiated immediately.
+// This is hopefully good enough for now - in case we get very many expiring subscriptions, might have
+// to look for an approach that scales better.
+fn schedule_unsubscribe(
+    expiry: u128,
+    subscriber: UUri,
+    topic: UUri,
+    sender: Sender<InternalSubscriptionEvent>,
+) {
+    tokio::spawn(async move {
+        if let Some(delay) = helpers::duration_until_timestamp(expiry) {
+            sleep(delay).await;
+        }
+
+        let _ = sender
+            .send(InternalSubscriptionEvent::RemoveExpiredSubscription { subscriber, topic })
+            .await;
+    });
 }
 
 // Create a remote Subscribe UUri from a (topic) uri; copies the UUri authority and
@@ -637,6 +729,9 @@ mod tests {
     // These are tests just for the locally used helper functions of subscription manager. More complex and complete
     // tests of the susbcription manager business logic are located in tests/subscription_manager_tests.rs
 
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::time::{Duration, Instant};
+
     use super::*;
     use crate::test_lib::{self};
     use up_rust::MockLocalUriProvider;
@@ -645,6 +740,76 @@ mod tests {
         let mut mock_provider = MockLocalUriProvider::new();
         mock_provider.expect_get_source_uri().return_const(uri);
         mock_provider
+    }
+
+    #[tokio::test]
+    async fn test_schedule_future_unsubscribe() {
+        let (internal_cmd_sender, mut internal_cmd_receiver) =
+            mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
+
+        let start = Instant::now();
+        let expiry_in_1s = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            + 1000;
+
+        schedule_unsubscribe(
+            expiry_in_1s,
+            test_lib::helpers::subscriber_uri1(),
+            test_lib::helpers::local_topic1_uri(),
+            internal_cmd_sender,
+        );
+
+        let message = internal_cmd_receiver.recv().await;
+        if let Some(InternalSubscriptionEvent::RemoveExpiredSubscription { subscriber, topic }) =
+            message
+        {
+            // Dunno how flaky this might turn out to be - but let's test if there is at least a second elapsed between scheduling the
+            // unsubscribe task and it's reaction to the expiration timer 1s in the future...
+            let elapsed = start.elapsed();
+            assert!(elapsed >= Duration::from_millis(1000));
+
+            assert_eq!(topic, test_lib::helpers::local_topic1_uri());
+            assert_eq!(subscriber, test_lib::helpers::subscriber_uri1());
+        } else {
+            panic!("Expected RemoveExpiredSubscription event from scheduled task");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_schedule_past_unsubscribe() {
+        let (internal_cmd_sender, mut internal_cmd_receiver) =
+            mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
+
+        let start = Instant::now();
+        let expiry_in_1s = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            - 1000;
+
+        schedule_unsubscribe(
+            expiry_in_1s,
+            test_lib::helpers::subscriber_uri1(),
+            test_lib::helpers::local_topic1_uri(),
+            internal_cmd_sender,
+        );
+
+        let message = internal_cmd_receiver.recv().await;
+        if let Some(InternalSubscriptionEvent::RemoveExpiredSubscription { subscriber, topic }) =
+            message
+        {
+            // Dunno how flaky this might turn out to be - but let's test if there is at most half a second elapsed between scheduling the
+            // unsubscribe task and it's reaction to the expiration timer 1s in the past...
+            let elapsed = start.elapsed();
+            assert!(elapsed < Duration::from_millis(500));
+
+            assert_eq!(topic, test_lib::helpers::local_topic1_uri());
+            assert_eq!(subscriber, test_lib::helpers::subscriber_uri1());
+        } else {
+            panic!("Expected RemoveExpiredSubscription event from scheduled task");
+        }
     }
 
     #[tokio::test]
@@ -677,7 +842,8 @@ mod tests {
             test_lib::mocks::utransport_mock_for_rpc(vec![(expected_request, expected_response)])
                 .await,
         );
-        let (sender, mut receiver) = mpsc::unbounded_channel::<RemoteSubscriptionEvent>();
+        let (sender, mut receiver) =
+            mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
 
         // perform operation to test
         let result = remote_subscribe(
@@ -692,12 +858,10 @@ mod tests {
         assert!(result.is_ok());
         let response = receiver.recv().await;
         assert!(response.is_some());
-        match response.unwrap() {
-            RemoteSubscriptionEvent::RemoteTopicStateUpdate { topic, state } => {
-                assert_eq!(topic, expected_topic);
-                assert_eq!(state, TopicState::SUBSCRIBED);
-            }
-        }
+        if let InternalSubscriptionEvent::TopicStateUpdate { topic, state } = response.unwrap() {
+            assert_eq!(topic, expected_topic);
+            assert_eq!(state, TopicState::SUBSCRIBED);
+        };
     }
 
     #[tokio::test]
@@ -718,7 +882,8 @@ mod tests {
         };
 
         // set up mocks
-        let (sender, mut receiver) = mpsc::unbounded_channel::<RemoteSubscriptionEvent>();
+        let (sender, mut receiver) =
+            mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
         let mock_transport = Arc::new(
             test_lib::mocks::utransport_mock_for_rpc(vec![(expected_request, expected_response)])
                 .await,
@@ -737,12 +902,10 @@ mod tests {
         assert!(result.is_ok());
         let response = receiver.recv().await;
         assert!(response.is_some());
-        match response.unwrap() {
-            RemoteSubscriptionEvent::RemoteTopicStateUpdate { topic, state } => {
-                assert_eq!(topic, expected_topic);
-                assert_eq!(state, TopicState::UNSUBSCRIBED);
-            }
-        }
+        if let InternalSubscriptionEvent::TopicStateUpdate { topic, state } = response.unwrap() {
+            assert_eq!(topic, expected_topic);
+            assert_eq!(state, TopicState::UNSUBSCRIBED);
+        };
     }
 
     #[test]

--- a/up-subscription/src/subscription_manager.rs
+++ b/up-subscription/src/subscription_manager.rs
@@ -14,7 +14,7 @@
 use log::*;
 #[cfg(test)]
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::{
     sync::{mpsc, mpsc::Receiver, mpsc::Sender, oneshot, Notify},
     time::sleep,
@@ -43,12 +43,17 @@ use crate::{
 // via tokio mpsc channel. This design allows to forgo the use of any synhronization primitives on the subscription-tracking container
 // data types, as any access is coordinated/serialized via the Event selection loop.
 
-// Maximum number of `Subscriber` entries to be returned in a `FetchSusbcriptions´ operation
+// Maximum number of `Subscriber` entries to be returned in a `FetchSusbcriptions´ operation.
 const UP_MAX_FETCH_SUBSCRIBERS_LEN: usize = 100;
-// Maximum number of `Subscriber` entries to be returned in a `FetchSusbcriptions´ operation
+// Maximum number of `Subscriber` entries to be returned in a `FetchSusbcriptions´ operation.
 const UP_MAX_FETCH_SUBSCRIPTIONS_LEN: usize = 100;
 
+// Queue size of message channel for internal commands - like subscription status change messages or subscription expiration commands.
 const INTERNAL_COMMAND_BUFFER_SIZE: usize = 128;
+
+// Timeout to use when sending subscription removal command after a subscription has expired; if exceeded, subscription won't be removed
+// directly but will be cleaned up at next startup.
+const SUBSCRIPTION_EXPIRY_REMOVAL_TIMEOUT_SECONDS: u64 = 5;
 
 #[derive(Debug)]
 pub(crate) enum RequestKind {
@@ -688,14 +693,19 @@ fn schedule_unsubscribe(
     topic: TopicUUri,
     sender: Sender<InternalSubscriptionEvent>,
 ) {
-    tokio::spawn(async move {
+    helpers::spawn_and_log_error(async move {
         if let Some(delay) = helpers::duration_until_timestamp(expiry) {
             sleep(delay).await;
         }
 
-        let _ = sender
-            .send(InternalSubscriptionEvent::RemoveExpiredSubscription { subscriber, topic })
-            .await;
+        sender
+            .send_timeout(
+                InternalSubscriptionEvent::RemoveExpiredSubscription { subscriber, topic },
+                Duration::from_secs(SUBSCRIPTION_EXPIRY_REMOVAL_TIMEOUT_SECONDS),
+            )
+            .await?;
+
+        Ok(())
     });
 }
 

--- a/up-subscription/src/subscription_manager.rs
+++ b/up-subscription/src/subscription_manager.rs
@@ -31,8 +31,11 @@ use up_rust::{
 };
 
 use crate::{
-    helpers, notification_manager, notification_manager::NotificationEvent, persistency,
-    usubscription, USubscriptionConfiguration,
+    helpers, notification_manager,
+    notification_manager::NotificationEvent,
+    persistency,
+    usubscription::{ExpiryTimestamp, SubscriberUUri, TopicUUri, UP_REMOTE_TTL},
+    USubscriptionConfiguration,
 };
 
 // This is the core business logic for handling and tracking subscriptions. It is currently implemented as a single event-consuming
@@ -49,36 +52,36 @@ const INTERNAL_COMMAND_BUFFER_SIZE: usize = 128;
 
 #[derive(Debug)]
 pub(crate) enum RequestKind {
-    Subscriber(UUri),
-    Topic(UUri),
+    Subscriber(SubscriberUUri),
+    Topic(TopicUUri),
 }
 
 #[derive(Debug)]
 pub(crate) struct SubscriptionEntry {
-    pub(crate) topic: UUri,
-    pub(crate) subscriber: UUri,
+    pub(crate) topic: TopicUUri,
+    pub(crate) subscriber: SubscriberUUri,
     pub(crate) status: SubscriptionStatus,
 }
 
-pub(crate) type SubscribersResponse = (Vec<UUri>, bool); // List of subscribers, boolean flag stating if there exist more entries than contained in list
+pub(crate) type SubscribersResponse = (Vec<SubscriberUUri>, bool); // List of subscribers, boolean flag stating if there exist more entries than contained in list
 pub(crate) type SubscriptionsResponse = (Vec<SubscriptionEntry>, bool); // List of subscriber entries, boolean flag stating if there exist more entries than contained in list
 
 // This is the 'outside API' of subscription manager, it includes some events that are only to be used in (and only enabled for) testing.
 #[derive(Debug)]
 pub(crate) enum SubscriptionEvent {
     AddSubscription {
-        subscriber: UUri,
-        topic: UUri,
-        expiry: Option<usubscription::ExpiryTimestamp>,
+        subscriber: SubscriberUUri,
+        topic: TopicUUri,
+        expiry: Option<ExpiryTimestamp>,
         respond_to: oneshot::Sender<SubscriptionStatus>,
     },
     RemoveSubscription {
-        subscriber: UUri,
-        topic: UUri,
+        subscriber: SubscriberUUri,
+        topic: TopicUUri,
         respond_to: oneshot::Sender<SubscriptionStatus>,
     },
     FetchSubscribers {
-        topic: UUri,
+        topic: TopicUUri,
         offset: Option<u32>,
         respond_to: oneshot::Sender<SubscribersResponse>, // return list of subscribers and flag indicating whether there are more
     },
@@ -101,12 +104,12 @@ pub(crate) enum SubscriptionEvent {
     // Purely for use during testing: get copy of current topic-subscriper ledger
     #[cfg(test)]
     GetRemoteTopics {
-        respond_to: oneshot::Sender<HashMap<UUri, TopicState>>,
+        respond_to: oneshot::Sender<HashMap<TopicUUri, TopicState>>,
     },
     // Purely for use during testing: force-set new topic-subscriber ledger
     #[cfg(test)]
     SetRemoteTopics {
-        topic_subscribers_replacement: HashMap<UUri, TopicState>,
+        topic_subscribers_replacement: HashMap<TopicUUri, TopicState>,
         respond_to: oneshot::Sender<()>,
     },
     // Purely for use during testing: get internal remote-subscription-change command sender
@@ -119,8 +122,14 @@ pub(crate) enum SubscriptionEvent {
 // Internal subscription manager API - used to update on remote subscriptions (deal with _PENDING states)
 #[derive(Debug)]
 pub(crate) enum InternalSubscriptionEvent {
-    TopicStateUpdate { topic: UUri, state: TopicState },
-    RemoveExpiredSubscription { subscriber: UUri, topic: UUri },
+    TopicStateUpdate {
+        topic: TopicUUri,
+        state: TopicState,
+    },
+    RemoveExpiredSubscription {
+        subscriber: SubscriberUUri,
+        topic: TopicUUri,
+    },
 }
 
 // Wrapper type, include all kinds of actions subscription manager knows
@@ -401,9 +410,9 @@ fn add_subscription(
     internal_cmd_sender: Sender<InternalSubscriptionEvent>,
     topic_subscribers: &mut persistency::SubscriptionsStore,
     remote_topics: &mut persistency::RemoteTopicsStore,
-    subscriber: UUri,
-    topic: UUri,
-    expiry: Option<usubscription::ExpiryTimestamp>,
+    subscriber: SubscriberUUri,
+    topic: TopicUUri,
+    expiry: Option<ExpiryTimestamp>,
 ) -> Result<SubscriptionStatus, persistency::PersistencyError> {
     let _ = topic_subscribers.add_subscription(&subscriber, &topic, expiry)?;
 
@@ -455,8 +464,8 @@ fn remove_subscription(
     internal_cmd_sender: Sender<InternalSubscriptionEvent>,
     topic_subscribers: &mut persistency::SubscriptionsStore,
     remote_topics: &mut persistency::RemoteTopicsStore,
-    subscriber: UUri,
-    topic: UUri,
+    subscriber: SubscriberUUri,
+    topic: TopicUUri,
 ) -> Result<SubscriptionStatus, persistency::PersistencyError> {
     // if this was the last subscriber to topic and topic is remote
     if topic_subscribers.remove_subscription(&subscriber, &topic)?
@@ -482,7 +491,7 @@ fn remove_subscription(
 // Fetch all subscribers of a topic
 fn fetch_subscribers(
     topic_subscribers: &persistency::SubscriptionsStore,
-    topic: UUri,
+    topic: TopicUUri,
     offset: Option<u32>,
 ) -> Result<SubscribersResponse, persistency::PersistencyError> {
     // This will get *every* client that subscribed to `topic` - no matter whether (in the case of remote subscriptions)
@@ -563,7 +572,7 @@ fn fetch_subscriptions(
 
 // Perform remote topic subscription
 async fn remote_subscribe(
-    topic: UUri,
+    topic: TopicUUri,
     uri_provider: Arc<dyn LocalUriProvider>,
     transport: Arc<dyn UTransport>,
     internal_cmd_sender: Sender<InternalSubscriptionEvent>,
@@ -584,12 +593,7 @@ async fn remote_subscribe(
     let subscription_response: SubscriptionResponse = rpc_client
         .invoke_proto_method(
             make_remote_subscribe_uuri(&subscription_request.topic),
-            CallOptions::for_rpc_request(
-                usubscription::UP_REMOTE_TTL,
-                None,
-                None,
-                Some(UPriority::UPRIORITY_CS4),
-            ),
+            CallOptions::for_rpc_request(UP_REMOTE_TTL, None, None, Some(UPriority::UPRIORITY_CS4)),
             subscription_request,
         )
         .await
@@ -619,7 +623,7 @@ async fn remote_subscribe(
 
 // Perform remote topic unsubscription
 async fn remote_unsubscribe(
-    topic: UUri,
+    topic: TopicUUri,
     uri_provider: Arc<dyn LocalUriProvider>,
     transport: Arc<dyn UTransport>,
     internal_cmd_sender: Sender<InternalSubscriptionEvent>,
@@ -640,12 +644,7 @@ async fn remote_unsubscribe(
     let unsubscribe_response: UStatus = rpc_client
         .invoke_proto_method(
             make_remote_unsubscribe_uuri(&unsubscribe_request.topic),
-            CallOptions::for_rpc_request(
-                usubscription::UP_REMOTE_TTL,
-                None,
-                None,
-                Some(UPriority::UPRIORITY_CS4),
-            ),
+            CallOptions::for_rpc_request(UP_REMOTE_TTL, None, None, Some(UPriority::UPRIORITY_CS4)),
             unsubscribe_request,
         )
         .await
@@ -685,8 +684,8 @@ async fn remote_unsubscribe(
 // to look for an approach that scales better.
 fn schedule_unsubscribe(
     expiry: u128,
-    subscriber: UUri,
-    topic: UUri,
+    subscriber: SubscriberUUri,
+    topic: TopicUUri,
     sender: Sender<InternalSubscriptionEvent>,
 ) {
     tokio::spawn(async move {

--- a/up-subscription/src/subscription_manager.rs
+++ b/up-subscription/src/subscription_manager.rs
@@ -683,7 +683,7 @@ async fn remote_unsubscribe(
 // This is hopefully good enough for now - in case we get very many expiring subscriptions, might have
 // to look for an approach that scales better.
 fn schedule_unsubscribe(
-    expiry: u128,
+    expiry: ExpiryTimestamp,
     subscriber: SubscriberUUri,
     topic: TopicUUri,
     sender: Sender<InternalSubscriptionEvent>,

--- a/up-subscription/src/tests/mod.rs
+++ b/up-subscription/src/tests/mod.rs
@@ -14,4 +14,5 @@
 pub(crate) mod test_lib;
 
 mod notification_manager_tests;
+mod persistency_tests;
 mod subscription_manager_tests;

--- a/up-subscription/src/tests/persistency_tests.rs
+++ b/up-subscription/src/tests/persistency_tests.rs
@@ -1,0 +1,75 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::time::{sleep, Duration};
+
+    use crate::{persistency, test_lib, USubscriptionConfiguration};
+
+    fn get_configuration() -> USubscriptionConfiguration {
+        USubscriptionConfiguration::create(
+            test_lib::helpers::LOCAL_AUTHORITY.to_string(),
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_and_prune_expiring_subscriptions() {
+        let mut subscriptions = persistency::SubscriptionsStore::new(&get_configuration());
+
+        // Prepare subscription persistency with two subscriptions, one with and one without expiry timestamp
+        let expiry_in_1s = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            + 1000;
+        let _ = subscriptions.add_subscription(
+            &test_lib::helpers::subscriber_uri1(),
+            &test_lib::helpers::local_topic1_uri(),
+            None,
+        );
+        let _ = subscriptions.add_subscription(
+            &test_lib::helpers::subscriber_uri2(),
+            &test_lib::helpers::local_topic2_uri(),
+            Some(expiry_in_1s),
+        );
+
+        // retrieve all persisted subscription relationships - should be the two we added above
+        #[allow(clippy::mutable_key_type)]
+        let data = subscriptions
+            .get_data()
+            .expect("Error interacting with subscription persistency");
+        assert!(data.len() == 2);
+
+        // get all subscriptions that have an expiration timestamp set - should be one, as added above
+        let list = subscriptions
+            .get_and_prune_expiring_subscriptions()
+            .expect("Error interacting with subscription persistency");
+        assert!(list.len() == 1);
+
+        // wait a second, this should result in the one subscription expiration timestamp to pass
+        sleep(Duration::from_millis(2000)).await;
+
+        // now, the one timed subscription we had should be pruned by get_and_prune_expiring_subscriptions() function call, so list should be empty
+        let list = subscriptions
+            .get_and_prune_expiring_subscriptions()
+            .expect("Error interacting with subscription persistency");
+        assert!(list.is_empty());
+    }
+}

--- a/up-subscription/src/tests/persistency_tests.rs
+++ b/up-subscription/src/tests/persistency_tests.rs
@@ -47,29 +47,41 @@ mod tests {
         let _ = subscriptions.add_subscription(
             &test_lib::helpers::subscriber_uri2(),
             &test_lib::helpers::local_topic2_uri(),
+            Some(1000),
+        );
+        let _ = subscriptions.add_subscription(
+            &test_lib::helpers::subscriber_uri3(),
+            &test_lib::helpers::local_topic2_uri(),
             Some(expiry_in_1s),
         );
 
-        // retrieve all persisted subscription relationships - should be the two we added above
-        #[allow(clippy::mutable_key_type)]
-        let data = subscriptions
-            .get_data()
+        let flattened_subscriptions = subscriptions
+            .get_flattened_subscriptions()
             .expect("Error interacting with subscription persistency");
-        assert!(data.len() == 2);
+        assert!(
+            flattened_subscriptions.len() == 3,
+            "Incorrect number of persisted subscription relationships - should be 3"
+        );
 
-        // get all subscriptions that have an expiration timestamp set - should be one, as added above
+        // get all subscriptions that have a future expiration timestamp set - should be 1, as one has None and another has a past timestamp
         let list = subscriptions
             .get_and_prune_expiring_subscriptions()
             .expect("Error interacting with subscription persistency");
-        assert!(list.len() == 1);
+        assert!(
+            list.len() == 1,
+            "There should only be 1 subscription with an expiration timer in persistency"
+        );
 
-        // wait a second, this should result in the one subscription expiration timestamp to pass
-        sleep(Duration::from_millis(2000)).await;
+        // wait a moment, this should result in the one subscription expiration timestamp to pass
+        sleep(Duration::from_millis(1500)).await;
 
         // now, the one timed subscription we had should be pruned by get_and_prune_expiring_subscriptions() function call, so list should be empty
         let list = subscriptions
             .get_and_prune_expiring_subscriptions()
             .expect("Error interacting with subscription persistency");
-        assert!(list.is_empty());
+        assert!(
+            list.is_empty(),
+            "There should be no subscription with an expiration timestamp left at this point"
+        );
     }
 }

--- a/up-subscription/src/tests/subscription_manager_tests.rs
+++ b/up-subscription/src/tests/subscription_manager_tests.rs
@@ -38,7 +38,9 @@ mod tests {
             handle_message, InternalSubscriptionEvent, RequestKind, SubscribersResponse,
             SubscriptionEntry, SubscriptionEvent, SubscriptionsResponse,
         },
-        test_lib, usubscription, USubscriptionConfiguration,
+        test_lib,
+        usubscription::{ExpiryTimestamp, SubscriberUUri, TopicUUri},
+        USubscriptionConfiguration,
     };
 
     // Simple subscription-manager-actor front-end to use for testing
@@ -217,9 +219,9 @@ mod tests {
 
         async fn subscribe(
             &self,
-            topic: UUri,
-            subscriber: UUri,
-            expiry: Option<usubscription::ExpiryTimestamp>,
+            topic: TopicUUri,
+            subscriber: SubscriberUUri,
+            expiry: Option<ExpiryTimestamp>,
         ) -> Result<SubscriptionStatus, Box<dyn Error>> {
             let (respond_to, receive_from) = oneshot::channel::<SubscriptionStatus>();
             let command = SubscriptionEvent::AddSubscription {
@@ -234,8 +236,8 @@ mod tests {
 
         async fn unsubscribe(
             &self,
-            topic: UUri,
-            subscriber: UUri,
+            topic: TopicUUri,
+            subscriber: SubscriberUUri,
         ) -> Result<SubscriptionStatus, Box<dyn Error>> {
             let (respond_to, receive_from) = oneshot::channel::<SubscriptionStatus>();
             let command = SubscriptionEvent::RemoveSubscription {
@@ -249,7 +251,7 @@ mod tests {
 
         async fn fetch_subscribers(
             &self,
-            topic: UUri,
+            topic: TopicUUri,
             offset: Option<u32>,
         ) -> Result<SubscribersResponse, Box<dyn Error>> {
             let (respond_to, receive_from) = oneshot::channel::<SubscribersResponse>();
@@ -302,8 +304,8 @@ mod tests {
             Ok(receive_from.await?)
         }
 
-        async fn get_remote_topics(&self) -> Result<HashMap<UUri, State>, Box<dyn Error>> {
-            let (respond_to, receive_from) = oneshot::channel::<HashMap<UUri, State>>();
+        async fn get_remote_topics(&self) -> Result<HashMap<TopicUUri, State>, Box<dyn Error>> {
+            let (respond_to, receive_from) = oneshot::channel::<HashMap<TopicUUri, State>>();
             let command = SubscriptionEvent::GetRemoteTopics { respond_to };
 
             self.command_sender.send(command).await?;
@@ -313,7 +315,7 @@ mod tests {
         #[allow(clippy::mutable_key_type)]
         async fn set_remote_topics(
             &self,
-            remote_topics_replacement: HashMap<UUri, State>,
+            remote_topics_replacement: HashMap<TopicUUri, State>,
         ) -> Result<(), Box<dyn Error>> {
             let (respond_to, receive_from) = oneshot::channel::<()>();
             let command = SubscriptionEvent::SetRemoteTopics {
@@ -351,7 +353,7 @@ mod tests {
          (test_lib::helpers::local_topic2_uri(), test_lib::helpers::subscriber_uri2())
          ]; "Multiple susbcriber-topic combinations")]
     #[tokio::test]
-    async fn test_subscribe(topic_subscribers: Vec<(UUri, UUri)>) {
+    async fn test_subscribe(topic_subscribers: Vec<(TopicUUri, SubscriberUUri)>) {
         helpers::init_once();
         let command_sender = CommandSender::new();
 
@@ -392,7 +394,7 @@ mod tests {
             .as_millis();
 
         // Prepare things
-        let mut desired_state: Vec<(UUri, UUri, Option<u128>)> = vec![
+        let mut desired_state: Vec<(SubscriberUUri, TopicUUri, Option<u128>)> = vec![
             (
                 test_lib::helpers::subscriber_uri1(),
                 test_lib::helpers::local_topic1_uri(),
@@ -425,15 +427,16 @@ mod tests {
         let actual_subscribers = command_sender.get_topic_subscribers().await;
         assert!(actual_subscribers.is_ok());
 
-        let flattened_subscribers: Vec<(UUri, UUri, Option<u128>)> = actual_subscribers
-            .unwrap()
-            .iter()
-            .flat_map(|(outer_key, inner_map)| {
-                inner_map
-                    .iter()
-                    .map(move |(inner_key, value)| (outer_key.clone(), inner_key.clone(), *value))
-            })
-            .collect();
+        let flattened_subscribers: Vec<(SubscriberUUri, TopicUUri, Option<u128>)> =
+            actual_subscribers
+                .unwrap()
+                .iter()
+                .flat_map(|(outer_key, inner_map)| {
+                    inner_map.iter().map(move |(inner_key, value)| {
+                        (outer_key.clone(), inner_key.clone(), *value)
+                    })
+                })
+                .collect();
 
         desired_state.remove(1); // Remote item that has expiry timestamp in the past, so hasn't been added by subscription manager
         assert_eq!(flattened_subscribers.len(), desired_state.len());
@@ -446,7 +449,7 @@ mod tests {
     #[test_case(test_lib::helpers::remote_topic1_uri(), State::SUBSCRIBE_PENDING; "Remote topic, remote state SUBSCRIBED_PENDING")]
     #[test_case(test_lib::helpers::remote_topic1_uri(), State::SUBSCRIBED; "Remote topic, remote state SUBSCRIBED")]
     #[tokio::test]
-    async fn test_remote_subscribe(remote_topic: UUri, remote_state: State) {
+    async fn test_remote_subscribe(remote_topic: TopicUUri, remote_state: State) {
         helpers::init_once();
 
         // Prepare things
@@ -697,7 +700,7 @@ mod tests {
             .expect("Interaction with subscription handler broken");
 
         #[allow(clippy::mutable_key_type)]
-        let mut desired_remote_state: HashMap<UUri, State> = HashMap::new();
+        let mut desired_remote_state: HashMap<TopicUUri, State> = HashMap::new();
         desired_remote_state.insert(remote_topic.clone(), State::SUBSCRIBED);
         command_sender
             .set_remote_topics(desired_remote_state)
@@ -764,7 +767,7 @@ mod tests {
             .expect("Interaction with subscription handler broken");
 
         #[allow(clippy::mutable_key_type)]
-        let mut desired_remote_state: HashMap<UUri, State> = HashMap::new();
+        let mut desired_remote_state: HashMap<TopicUUri, State> = HashMap::new();
         desired_remote_state.insert(remote_topic.clone(), State::SUBSCRIBED);
         command_sender
             .set_remote_topics(desired_remote_state)
@@ -1006,7 +1009,7 @@ mod tests {
         // Prepare things
         let desired_subscriber = test_lib::helpers::subscriber_uri1();
 
-        let mut expected_subscribers: Vec<(UUri, UUri)> = Vec::new();
+        let mut expected_subscribers: Vec<(SubscriberUUri, TopicUUri)> = Vec::new();
         for (topic, subscribers) in desired_state.clone() {
             if subscribers.contains_key(&desired_subscriber) {
                 if let Some((subscriber, _expiry)) = subscribers.get_key_value(&desired_subscriber)

--- a/up-subscription/src/tests/subscription_manager_tests.rs
+++ b/up-subscription/src/tests/subscription_manager_tests.rs
@@ -17,23 +17,28 @@ mod tests {
     use std::collections::HashMap;
     use std::error::Error;
     use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use test_case::test_case;
-    use tokio::sync::{mpsc, mpsc::Sender, mpsc::UnboundedSender, oneshot, Notify};
-    use up_rust::MockTransport;
+    use tokio::sync::{mpsc, mpsc::Sender, oneshot, Notify};
 
-    use up_rust::core::usubscription::{
-        State, SubscriptionRequest, SubscriptionResponse, SubscriptionStatus, UnsubscribeRequest,
+    use up_rust::{
+        core::usubscription::{
+            State, SubscriptionRequest, SubscriptionResponse, SubscriptionStatus,
+            UnsubscribeRequest,
+        },
+        MockTransport, UCode, UStatus, UUri,
     };
-    use up_rust::{UCode, UStatus, UUri};
 
-    use crate::configuration::DEFAULT_COMMAND_BUFFER_SIZE;
-    use crate::subscription_manager::{
-        handle_message, RemoteSubscriptionEvent, RequestKind, SubscribersResponse,
-        SubscriptionEntry, SubscriptionEvent, SubscriptionsResponse,
-    };
     use crate::{
-        helpers, notification_manager::NotificationEvent, persistency, test_lib, usubscription,
-        USubscriptionConfiguration,
+        configuration::DEFAULT_COMMAND_BUFFER_SIZE,
+        helpers,
+        notification_manager::NotificationEvent,
+        persistency,
+        subscription_manager::{
+            handle_message, InternalSubscriptionEvent, RequestKind, SubscribersResponse,
+            SubscriptionEntry, SubscriptionEvent, SubscriptionsResponse,
+        },
+        test_lib, usubscription, USubscriptionConfiguration,
     };
 
     // Simple subscription-manager-actor front-end to use for testing
@@ -57,8 +62,33 @@ mod tests {
             let shutdown_notification = Arc::new(Notify::new());
             let (command_sender, command_receiver) =
                 mpsc::channel::<SubscriptionEvent>(DEFAULT_COMMAND_BUFFER_SIZE);
-            let (notification_sender, _) =
+            let (notification_sender, mut notification_receiver) =
                 mpsc::channel::<NotificationEvent>(config.notification_command_buffer);
+
+            // Spawn notification receiver task
+            helpers::spawn_and_log_error(async move {
+                match notification_receiver.recv().await {
+                    Some(NotificationEvent::StateChange {
+                        subscriber,
+                        topic,
+                        status,
+                        respond_to,
+                    }) => {
+                        println!(
+                            "Change Notification received: {} - {} - {}",
+                            subscriber.unwrap().to_uri(true),
+                            topic.to_uri(true),
+                            status
+                        );
+
+                        let _ = respond_to.send(());
+                    }
+                    _ => {
+                        panic!("Expected a notification message, got nothing")
+                    }
+                }
+                Ok(())
+            });
 
             helpers::spawn_and_log_error(async move {
                 handle_message(
@@ -94,20 +124,6 @@ mod tests {
             let (notification_sender, mut notification_receiver) =
                 mpsc::channel::<NotificationEvent>(config.notification_command_buffer);
 
-            // Spawn off subscription manager task
-            helpers::spawn_and_log_error(async move {
-                handle_message(
-                    config.clone(),
-                    Arc::new(transport_mock),
-                    command_receiver,
-                    notification_sender,
-                    shutdown_notification,
-                )
-                .await;
-
-                Ok(())
-            });
-
             // Spawn notification receiver task
             helpers::spawn_and_log_error(async move {
                 match notification_receiver.recv().await {
@@ -135,6 +151,20 @@ mod tests {
                         panic!("Expected a notification message, got nothing")
                     }
                 }
+                Ok(())
+            });
+
+            // Spawn off subscription manager task
+            helpers::spawn_and_log_error(async move {
+                handle_message(
+                    config.clone(),
+                    Arc::new(transport_mock),
+                    command_receiver,
+                    notification_sender,
+                    shutdown_notification,
+                )
+                .await;
+
                 Ok(())
             });
 
@@ -297,9 +327,9 @@ mod tests {
 
         async fn get_remote_subcription_change_sender(
             &self,
-        ) -> Result<UnboundedSender<RemoteSubscriptionEvent>, Box<dyn Error>> {
+        ) -> Result<Sender<InternalSubscriptionEvent>, Box<dyn Error>> {
             let (respond_to, receive_from) =
-                oneshot::channel::<UnboundedSender<RemoteSubscriptionEvent>>();
+                oneshot::channel::<Sender<InternalSubscriptionEvent>>();
             let command = SubscriptionEvent::GetRemoteSubscriptionChangeSender { respond_to };
 
             self.command_sender.send(command).await?;
@@ -351,26 +381,40 @@ mod tests {
         assert_eq!(topic_subscribers, desired_state);
     }
 
-    #[test_case(vec![(UUri::default(), UUri::default(), None)]; "Default susbcriber-topic-no_expiry")]
-    #[test_case(vec![(UUri::default(), UUri::default(), Some(1000))]; "Default susbcriber-topic-some_expiry")]
     #[tokio::test]
-    async fn test_subscribe_with_expiry(
-        topic_subscribers: Vec<(UUri, UUri, Option<usubscription::ExpiryTimestamp>)>,
-    ) {
+    async fn test_subscribe_with_expiry() {
         helpers::init_once();
         let command_sender = CommandSender::new();
 
-        // Prepare things
-        #[allow(clippy::mutable_key_type)]
-        let mut desired_state: persistency::SubscriptionSet = HashMap::new();
-        for (topic, subscriber, expiry) in topic_subscribers {
-            desired_state
-                .entry(topic.clone())
-                .or_default()
-                .insert(subscriber.clone(), expiry);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Error getting now timestamp")
+            .as_millis();
 
+        // Prepare things
+        let mut desired_state: Vec<(UUri, UUri, Option<u128>)> = vec![
+            (
+                test_lib::helpers::subscriber_uri1(),
+                test_lib::helpers::local_topic1_uri(),
+                None,
+            ),
+            (
+                test_lib::helpers::subscriber_uri2(),
+                test_lib::helpers::local_topic2_uri(),
+                Some(1000),
+            ),
+            (
+                test_lib::helpers::subscriber_uri3(),
+                test_lib::helpers::local_topic2_uri(),
+                Some(now + 1000),
+            ),
+        ];
+
+        for (subscriber, topic, expiry) in desired_state.iter() {
             // Operation to test
-            let result = command_sender.subscribe(topic, subscriber, expiry).await;
+            let result = command_sender
+                .subscribe(topic.clone(), subscriber.clone(), *expiry)
+                .await;
             assert!(result.is_ok());
 
             // Verify operation result content
@@ -378,12 +422,25 @@ mod tests {
         }
 
         // Verify iternal bookeeping
-        let topic_subscribers = command_sender.get_topic_subscribers().await;
-        assert!(topic_subscribers.is_ok());
-        #[allow(clippy::mutable_key_type)]
-        let topic_subscribers = topic_subscribers.unwrap();
-        assert_eq!(topic_subscribers.len(), desired_state.len());
-        assert_eq!(topic_subscribers, desired_state);
+        let actual_subscribers = command_sender.get_topic_subscribers().await;
+        assert!(actual_subscribers.is_ok());
+
+        let flattened_subscribers: Vec<(UUri, UUri, Option<u128>)> = actual_subscribers
+            .unwrap()
+            .iter()
+            .flat_map(|(outer_key, inner_map)| {
+                inner_map
+                    .iter()
+                    .map(move |(inner_key, value)| (outer_key.clone(), inner_key.clone(), *value))
+            })
+            .collect();
+
+        desired_state.remove(1); // Remote item that has expiry timestamp in the past, so hasn't been added by subscription manager
+        assert_eq!(flattened_subscribers.len(), desired_state.len());
+
+        for (topic, subscriber, expiry) in flattened_subscribers {
+            assert!(desired_state.contains(&(subscriber, topic, expiry)));
+        }
     }
 
     #[test_case(test_lib::helpers::remote_topic1_uri(), State::SUBSCRIBE_PENDING; "Remote topic, remote state SUBSCRIBED_PENDING")]
@@ -850,10 +907,12 @@ mod tests {
             .expect("Error retrieving remote-subscription change event command channel");
 
         // Initiate notification event
-        let _ = sender.send(RemoteSubscriptionEvent::RemoteTopicStateUpdate {
-            topic: topic.clone(),
-            state: State::SUBSCRIBE_PENDING,
-        });
+        let _ = sender
+            .send(InternalSubscriptionEvent::TopicStateUpdate {
+                topic: topic.clone(),
+                state: State::SUBSCRIBE_PENDING,
+            })
+            .await;
 
         // ensure that we have run through all the async layers and reached the notification assertion statements
         let _ = state_changed.await;

--- a/up-subscription/src/tests/subscription_manager_tests.rs
+++ b/up-subscription/src/tests/subscription_manager_tests.rs
@@ -394,7 +394,7 @@ mod tests {
             .as_millis();
 
         // Prepare things
-        let mut desired_state: Vec<(SubscriberUUri, TopicUUri, Option<u128>)> = vec![
+        let mut desired_state: Vec<(SubscriberUUri, TopicUUri, Option<ExpiryTimestamp>)> = vec![
             (
                 test_lib::helpers::subscriber_uri1(),
                 test_lib::helpers::local_topic1_uri(),
@@ -427,7 +427,7 @@ mod tests {
         let actual_subscribers = command_sender.get_topic_subscribers().await;
         assert!(actual_subscribers.is_ok());
 
-        let flattened_subscribers: Vec<(SubscriberUUri, TopicUUri, Option<u128>)> =
+        let flattened_subscribers: Vec<(SubscriberUUri, TopicUUri, Option<ExpiryTimestamp>)> =
             actual_subscribers
                 .unwrap()
                 .iter()

--- a/up-subscription/src/usubscription.rs
+++ b/up-subscription/src/usubscription.rs
@@ -51,8 +51,10 @@ pub const INCLUDE_SCHEMA: bool = false;
 // Remote-subscribe operation ttl; 5 minutes in milliseconds, as per https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l3/usubscription/v3#6-timeout--retry-logic
 pub(crate) const UP_REMOTE_TTL: u32 = 300000;
 
-// Centralized definition, make it easier to accomodate potential changes to expiry type in up-spec
+// Alias definitions to provide more clarity, and make it easier to accomodate potential changes to expiry type in up-spec
 pub(crate) type ExpiryTimestamp = u128;
+pub(crate) type SubscriberUUri = UUri;
+pub(crate) type TopicUUri = UUri;
 
 /// This trait primarily serves to provide a hook-point for using the mockall crate, for mocking USubscriptionService objects
 /// where we also need/want to inject custom/mock UTransport implementations that subsequently get used in test cases.


### PR DESCRIPTION
This is the code that implements timed subscription expiration. There are two fundamental aspects implemented here:

- when a new subscription is added, timed expiration functionality is added
- at startup, subscription manager will inspect all persisted subscriptions, and auto-remove any that have an expiration timestamp in the past