### PR TITLE
Include up-rust devcontainer improvements for multi-platform capability

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,7 +45,3 @@ USER ${USERNAME}
 
 # Install cargo cli tools
 RUN cargo install cargo-nextest cargo-deny cargo-tarpaulin --locked
-
-# Install cargo tools for cross compilation
-RUN rustup target add aarch64-unknown-linux-gnu \
-    && rustup toolchain install stable-aarch64-unknown-linux-gnu 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,9 @@
     "mounts": [
         "source=rust-volume,target=/rust-volume,type=volume"
     ],
+    "containerEnv": {
+        "WORKSPACE_FOLDER": "${containerWorkspaceFolder}"
+    },
     "postCreateCommand": "sudo .devcontainer/post-create.sh",
     "customizations": {
         "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,15 +1,38 @@
 #!/bin/bash
 
-# This is a workaround which is againt necessary on MacOS 14.0, it looks like this bug is back:
-# https://github.com/microsoft/vscode-dev-containers/issues/1487#issuecomment-1143907307
+#region sudo stuff
 
-# grant permissions to mounted rust volume
-chown vscode:vscode /rust-volume
+HOST_OS=""
+ARCH_AND_OS_FUNC="${WORKSPACE_FOLDER}.devcontainer/scripts/functions/get-arch-and-os.sh"
+if [[ -f "$ARCH_AND_OS_FUNC" ]]; then
+    source $ARCH_AND_OS_FUNC
+    read -r _ HOST_OS <<< "$(get_arch_and_os)"
+fi
+if [[ "$HOST_OS" == "darwin" ]]; then # darwin == Mac OS
+    # This is a workaround which is againt necessary on MacOS 14.0, it looks like this bug is back:
+    # https://github.com/microsoft/vscode-dev-containers/issues/1487#issuecomment-1143907307
+    # grant permissions to mounted rust volume
+    echo "(Mac OS only) Granting permissions to mounted rust volume"
+    sudo chown vscode:vscode /rust-volume
 
-# create /.cargo/config.toml in root folder
-mkdir /.cargo/
-touch /.cargo/config.toml
-cat <<EOF >/.cargo/config.toml
-[build]
-target-dir = "/rust-volume/target"
-EOF
+    # create /.cargo/config.toml in root folder
+    sudo mkdir /.cargo/
+    sudo touch /.cargo/config.toml
+    sudo bash -c "cat << EOF > /.cargo/config.toml
+    [build]
+    target-dir = \"/rust-volume/target\"
+    EOF"
+fi
+
+#endregion
+
+for arg in "$@"; do
+    if [[ "$arg" == --workspace-folder=* ]]; then
+        WORKSPACE_FOLDER="${arg#--workspace-folder=}"
+    fi
+done
+INSTALL_RUST_TOOLCHAIN_FUNC="${WORKSPACE_FOLDER}.devcontainer/scripts/functions/install-rust-toolchain.sh"
+if [[ -f "$INSTALL_RUST_TOOLCHAIN_FUNC" ]]; then
+    source $INSTALL_RUST_TOOLCHAIN_FUNC
+    install_rust_toolchain "$@"
+fi

--- a/.devcontainer/scripts/get-arch-and-os.sh
+++ b/.devcontainer/scripts/get-arch-and-os.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+get_arch_and_os() {
+    ARCH=$(uname -m)
+    OS=$(uname -s | tr "[:upper:]" "[:lower:]")
+
+    case "$ARCH" in
+    x86_64)
+        TARGET_ARCH="x86_64"
+        ;;
+    aarch64 | arm64)
+        TARGET_ARCH="aarch64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+    esac
+
+    case "$OS" in
+    linux)
+        TARGET_OS="unknown-linux-gnu"
+        ;;
+    *)
+        echo "OS is unsupported or not implemented in this script: $OS"
+        exit 1
+        ;;
+    esac
+    echo "$TARGET_ARCH $TARGET_OS"
+}

--- a/.devcontainer/scripts/install-rust-toolchain.sh
+++ b/.devcontainer/scripts/install-rust-toolchain.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+install_rust_toolchain() {
+    source ${WORKSPACE_FOLDER}/.devcontainer/scripts/functions/get-arch-and-os.sh
+    read -r TARGET_ARCH TARGET_OS <<< "$(get_arch_and_os)"
+    ARCH_AND_OS="${TARGET_ARCH}-${TARGET_OS}"
+    echo "Detected architecture and OS: $ARCH_AND_OS"
+    RUST_TOOLCHAIN="stable-$ARCH_AND_OS"
+    echo "Adding rustup target '$ARCH_AND_OS'"
+    rustup target add "$ARCH_AND_OS"
+    echo "Installing Rust toolchain for '$ARCH_AND_OS'"
+    rustup toolchain install "$RUST_TOOLCHAIN"
+}


### PR DESCRIPTION
Dynamic install of rust toolchain based on host arch and OS (as has been done in https://github.com/eclipse-uprotocol/up-rust/pull/275)

* dynamic install of rust toolchain based on host arch and OS
* wrap mac workaround script in OS check