### PR TITLE
Use tracing instead of log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,15 +480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-num"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822c4000301ac390e65995c62207501e3ef800a1fc441df913a5e8e4dc374816"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "clap_builder"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,29 +817,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -1581,30 +1549,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
 
 [[package]]
 name = "jni"
@@ -2396,15 +2340,6 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -3566,6 +3501,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+dependencies = [
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "testcontainers"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,16 +4064,15 @@ name = "up-subscription"
 version = "0.4.0"
 dependencies = [
  "async-trait",
- "env_logger",
- "log",
  "mockall 0.14.0",
  "pickledb",
  "protobuf",
  "serde",
  "test-case",
+ "test-log",
  "tokio",
+ "tracing",
  "up-rust",
- "uriparse",
 ]
 
 [[package]]
@@ -4125,10 +4080,10 @@ name = "up-subscription-cli"
 version = "0.4.0"
 dependencies = [
  "clap",
- "clap-num",
- "log",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "up-rust",
  "up-subscription",
  "up-transport-mqtt5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,11 @@ version = "0.4.0"
 
 [workspace.dependencies]
 async-trait = { version = "0.1" }
-env_logger = { version = "0.11" }
-log = { version = "0.4" }
 mockall = { version = "0.14" }
 protobuf = { version = "3.7.2" }
 test-case = { version = "3.3" }
 tokio = { version = "1", features = ["full"] }
+tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 up-rust = { version = "0.9.0", features = ["usubscription"] }
 up-subscription = { path = "./up-subscription" }
 

--- a/up-subscription-cli/Cargo.toml
+++ b/up-subscription-cli/Cargo.toml
@@ -28,18 +28,26 @@ license = false
 eula = false
 
 [features]
-default = ["local"]
-local = ["up-rust/util"]
+default = []
 mqtt5 = ["dep:up-transport-mqtt5"]
 zenoh = ["dep:up-transport-zenoh", "dep:serde_json"]
 
 [dependencies]
-clap = { version = "4.5", features = ["derive", "env"] }
-clap-num = { version = "1.2" }
-log = { workspace = true }
+clap = { version = "4.5.53", default-features = false, features = [
+    "std",
+    "derive",
+    "env",
+    "color",
+    "help",
+    "usage",
+    "error-context",
+    "suggestions",
+] }
 serde_json = { version = "1.0", optional = true }
 tokio = { workspace = true }
-up-rust = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+up-rust = { workspace = true, features = ["usubscription", "util" ] }
 up-subscription = { workspace = true }
 up-transport-mqtt5 = { version = "0.4.0", optional = true }
 up-transport-zenoh = { version = "0.9.0", optional = true }

--- a/up-subscription-cli/src/transport/local.rs
+++ b/up-subscription-cli/src/transport/local.rs
@@ -13,8 +13,11 @@
 
 use std::sync::Arc;
 
-use up_rust::{local_transport::LocalTransport, UStatus, UTransport};
+use tracing::info;
+use up_rust::{local_transport::LocalTransport, UTransport};
 
-pub(crate) async fn get_local_transport() -> Result<Arc<dyn UTransport>, UStatus> {
+pub(crate) async fn get_local_transport() -> Result<Arc<dyn UTransport>, Box<dyn std::error::Error>>
+{
+    info!("Using in-memory local uProtocol transport");
     Ok(Arc::new(LocalTransport::default()))
 }

--- a/up-subscription-cli/src/transport/mod.rs
+++ b/up-subscription-cli/src/transport/mod.rs
@@ -11,9 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-#[cfg(feature = "local")]
 pub(crate) mod local;
-#[cfg(feature = "local")]
 pub(crate) use local::get_local_transport;
 
 #[cfg(feature = "mqtt5")]

--- a/up-subscription-cli/src/transport/mqtt5.rs
+++ b/up-subscription-cli/src/transport/mqtt5.rs
@@ -13,16 +13,16 @@
 
 use std::sync::Arc;
 
-use up_rust::{LocalUriProvider, UStatus, UTransport};
+use tracing::info;
+use up_rust::UTransport;
 use up_transport_mqtt5::{Mqtt5Transport, Mqtt5TransportOptions};
 
 pub(crate) async fn get_mqtt5_transport(
-    uri_provider: Arc<dyn LocalUriProvider>,
+    authority_name: &str,
     mqtt5_args: Mqtt5TransportOptions,
-) -> Result<Arc<dyn UTransport>, UStatus> {
-    Ok(
-        Mqtt5Transport::new(mqtt5_args, uri_provider.get_authority())
-            .await
-            .map(Arc::new)?,
-    )
+) -> Result<Arc<dyn UTransport>, Box<dyn std::error::Error>> {
+    info!("Using MQTT 5 uProtocol transport");
+    Ok(Mqtt5Transport::new(mqtt5_args, authority_name)
+        .await
+        .map(Arc::new)?)
 }

--- a/up-subscription/Cargo.toml
+++ b/up-subscription/Cargo.toml
@@ -23,18 +23,17 @@ version.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
 pickledb = { version = "0.5.1" }
 protobuf = { workspace = true }
 serde = { version = "1.0" }
 tokio = { workspace = true }
+tracing = { workspace = true }
 up-rust = { workspace = true }
-uriparse = { version = "0.6" }
 
 [dev-dependencies]
 mockall = { workspace = true }
 test-case = { workspace = true }
+test-log ={ version = "0.2", default-features = false, features = ["trace"] }
 up-rust = { workspace = true, features = ["test-util"] }
 
 [package.metadata.dist]

--- a/up-subscription/src/common/helpers.rs
+++ b/up-subscription/src/common/helpers.rs
@@ -11,22 +11,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use log::*;
 use std::future::Future;
-use std::sync::Once;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::{task, time::Duration};
 
+use tokio::{task, time::Duration};
+use tracing::error;
 use up_rust::{
     communication::{ServiceInvocationError, UPayload},
     UAttributes, UUri,
 };
-
-static INIT: Once = Once::new();
-
-pub fn init_once() {
-    INIT.call_once(env_logger::init);
-}
 
 type SpawnResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 

--- a/up-subscription/src/handlers/fetch_subscribers.rs
+++ b/up-subscription/src/handlers/fetch_subscribers.rs
@@ -12,9 +12,8 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
-use log::*;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
-
+use tracing::error;
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
     core::usubscription::{
@@ -112,13 +111,11 @@ mod tests {
 
     use up_rust::UUri;
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-fetch-subscribers-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_subscribe_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let fetch_subscribers_request = FetchSubscribersRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -163,10 +160,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -191,10 +186,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -216,11 +209,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
-        // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
             ..Default::default()
@@ -238,10 +228,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -290,10 +278,8 @@ mod tests {
             resource_id: 0x0000_FFFF,
             ..Default::default()
         }; "Wildcard resource id in topic UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_topic_uri(topic: UUri) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request = test_lib::helpers::subscription_request(topic, None);
         let request_payload = UPayload::try_from_protobuf(subscribe_request.clone()).unwrap();

--- a/up-subscription/src/handlers/fetch_subscriptions.rs
+++ b/up-subscription/src/handlers/fetch_subscriptions.rs
@@ -12,9 +12,8 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
-use log::*;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
-
+use tracing::error;
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
     core::usubscription::{
@@ -153,13 +152,11 @@ mod tests {
 
     use up_rust::UUri;
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-fetch-subscriptions-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_fetch_subscriptions_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let fetch_subscriptions_request = FetchSubscriptionsRequest {
             request: Some(up_rust::core::usubscription::Request::Subscriber(
@@ -217,10 +214,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -245,10 +240,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -270,10 +263,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -292,10 +283,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -344,10 +333,8 @@ mod tests {
             resource_id: 0x0000_FFFF,
             ..Default::default()
         }; "Wildcard resource id in subscriber UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_subscriber_uri(subscriber: UUri) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let fetch_subscriptions_request = FetchSubscriptionsRequest {
             request: Some(up_rust::core::usubscription::Request::Subscriber(
@@ -403,10 +390,8 @@ mod tests {
             resource_id: 0x0000_FFFF,
             ..Default::default()
         }; "Wildcard resource id in topic UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_topic_uri(topic: UUri) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let fetch_subscriptions_request = FetchSubscriptionsRequest {
             request: Some(up_rust::core::usubscription::Request::Topic(topic)),

--- a/up-subscription/src/handlers/register_for_notifications.rs
+++ b/up-subscription/src/handlers/register_for_notifications.rs
@@ -12,9 +12,8 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
-use log::*;
 use tokio::sync::mpsc::Sender;
-
+use tracing::error;
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
     core::usubscription::{
@@ -93,13 +92,11 @@ mod tests {
 
     use up_rust::UUri;
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-register-notifications-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_register_notification_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -142,10 +139,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -172,10 +167,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -198,10 +191,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -223,10 +214,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -274,10 +263,8 @@ mod tests {
             resource_id: 0x0000_FFFF,
             ..Default::default()
         }; "Wildcard resource id in topic UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_topic_uri(topic: UUri) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(topic).into(),

--- a/up-subscription/src/handlers/reset.rs
+++ b/up-subscription/src/handlers/reset.rs
@@ -12,8 +12,8 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
-use log::*;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
+use tracing::error;
 
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
@@ -91,13 +91,11 @@ mod tests {
 
     use up_rust::UUri;
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-reset-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_reset_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let mut source_uri = test_lib::helpers::subscriber_uri1();
         source_uri.resource_id = up_rust::core::usubscription::USUBSCRIPTION_TYPE_ID;
@@ -133,10 +131,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let request_payload = UPayload::try_from_protobuf(ResetRequest::default()).unwrap();
         let message_attributes = UAttributes {
@@ -164,10 +160,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let request_payload = UPayload::try_from_protobuf(ResetRequest::default()).unwrap();
 
@@ -191,10 +185,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -217,10 +209,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let unsubscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -251,10 +241,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-reset-only-usubscription~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_source_entitytype() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let bad_source =
             UUri::try_from("up://local/1000/1/F").expect("Error during test case setup");

--- a/up-subscription/src/handlers/subscribe.rs
+++ b/up-subscription/src/handlers/subscribe.rs
@@ -11,11 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use async_trait::async_trait;
-use log::*;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::{sync::mpsc::Sender, sync::oneshot};
 
+use async_trait::async_trait;
+use tokio::{sync::mpsc::Sender, sync::oneshot};
+use tracing::error;
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
     core::usubscription::{
@@ -129,13 +129,11 @@ mod tests {
 
     use up_rust::{core::usubscription::State, UUri};
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-subscribe-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_subscribe_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -195,10 +193,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -224,10 +220,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -249,10 +243,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -271,10 +263,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -300,10 +290,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_future_subscription() {
-        helpers::init_once();
-
         let future_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -376,10 +364,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_expired_subscription() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request = test_lib::helpers::subscription_request(
             test_lib::helpers::local_topic1_uri(),
@@ -412,10 +398,8 @@ mod tests {
     #[test_case("up://*/100000/1/8AC7"; "Wildcard authority in topic UUri")]
     #[test_case("up://local/FFFF0000/1/8AC7"; "Wildcard entity id in topic UUri")]
     #[test_case("up://local/100000/1/FFFF"; "Wildcard resource id in topic UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_topic_uri(topic: &str) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let topic = UUri::from_str(topic).expect("Test parameter UUri failed to parse");
         let subscribe_request = test_lib::helpers::subscription_request(topic, None);

--- a/up-subscription/src/handlers/unregister_for_notifications.rs
+++ b/up-subscription/src/handlers/unregister_for_notifications.rs
@@ -12,9 +12,8 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
-use log::*;
 use tokio::sync::mpsc::Sender;
-
+use tracing::error;
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
     core::usubscription::{
@@ -99,13 +98,11 @@ mod tests {
 
     use up_rust::UUri;
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-unregister-notifications-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_unregister_notification_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -148,10 +145,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -178,10 +173,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let notification_request = NotificationsRequest {
             topic: Some(test_lib::helpers::local_topic1_uri()).into(),
@@ -204,10 +197,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -229,10 +220,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -262,10 +251,8 @@ mod tests {
     #[test_case("up://*/100000/1/8AC7"; "Wildcard authority in topic UUri")]
     #[test_case("up://local/FFFF0000/1/8AC7"; "Wildcard entity id in topic UUri")]
     #[test_case("up://local/100000/1/FFFF"; "Wildcard resource id in topic UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_topic_uri(topic: &str) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let topic = UUri::from_str(topic).expect("Test parameter UUri failed to parse");
         // create request and other required object(s)

--- a/up-subscription/src/handlers/unsubscribe.rs
+++ b/up-subscription/src/handlers/unsubscribe.rs
@@ -12,9 +12,8 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
-use log::*;
 use tokio::{sync::mpsc::Sender, sync::oneshot};
-
+use tracing::error;
 use up_rust::{
     communication::{RequestHandler, ServiceInvocationError, UPayload},
     core::usubscription::{
@@ -102,13 +101,11 @@ mod tests {
 
     use up_rust::{core::usubscription::State, UUri};
 
-    use crate::{helpers, tests::test_lib};
+    use crate::tests::test_lib;
 
     // [utest->dsn~usubscription-unsubscribe-protobuf~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_unsubscribe_success() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let unsubscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -162,10 +159,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_resource_id() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -191,10 +186,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_source_uri() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::unsubscribe_request(test_lib::helpers::local_topic1_uri());
@@ -216,10 +209,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_no_request_payload() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let message_attributes = UAttributes {
             source: Some(test_lib::helpers::subscriber_uri1()).into(),
@@ -238,10 +229,8 @@ mod tests {
         assert!(result.is_err_and(|err| matches!(err, ServiceInvocationError::InvalidArgument(_))));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_wrong_request_payload_type() {
-        helpers::init_once();
-
         // create request and other required object(s)
         let subscribe_request =
             test_lib::helpers::subscription_request(test_lib::helpers::local_topic1_uri(), None);
@@ -272,10 +261,8 @@ mod tests {
     #[test_case("up://*/100000/1/8AC7"; "Wildcard authority in topic UUri")]
     #[test_case("up://local/FFFF0000/1/8AC7"; "Wildcard entity id in topic UUri")]
     #[test_case("up://local/100000/1/FFFF"; "Wildcard resource id in topic UUri")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_invalid_topic_uri(topic: &str) {
-        helpers::init_once();
-
         // create request and other required object(s)
         let topic = UUri::from_str(topic).expect("Test parameter UUri failed to parse");
         let subscribe_request = test_lib::helpers::subscription_request(topic, None);

--- a/up-subscription/src/lib.rs
+++ b/up-subscription/src/lib.rs
@@ -38,7 +38,9 @@ For a batteries-included approach to running up-subscription-rust, the `up-subsc
 mod usubscription;
 pub use usubscription::*;
 mod configuration;
-pub use configuration::{ConfigurationError, USubscriptionConfiguration};
+pub use configuration::{
+    ConfigurationError, USubscriptionConfiguration, DEFAULT_COMMAND_BUFFER_SIZE,
+};
 
 // actors implementing the backend management logic for tracking subscriptions etc
 mod notification_manager;
@@ -62,7 +64,6 @@ pub(crate) mod handlers {
 mod common {
     pub(crate) mod helpers;
 }
-pub use common::helpers::init_once;
 pub(crate) use common::*;
 
 #[cfg(test)]

--- a/up-subscription/src/notification_manager.rs
+++ b/up-subscription/src/notification_manager.rs
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use log::*;
 use std::sync::Arc;
-use tokio::sync::{mpsc::Receiver, mpsc::Sender, oneshot, Notify};
 
+use tokio::sync::{mpsc::Receiver, mpsc::Sender, oneshot, Notify};
+use tracing::{debug, error, warn};
 use up_rust::{
     core::usubscription::{
         usubscription_uri, SubscriberInfo, SubscriptionStatus, Update,
@@ -24,7 +24,6 @@ use up_rust::{
 };
 
 use crate::{
-    helpers,
     persistency::{self, PersistencyError},
     usubscription::{SubscriberUUri, TopicUUri, INCLUDE_SCHEMA},
     USubscriptionConfiguration,
@@ -119,8 +118,6 @@ pub(crate) async fn notification_engine(
     mut events: Receiver<NotificationEvent>,
     shutdown: Arc<Notify>,
 ) {
-    helpers::init_once();
-
     // keep track of which subscriber wants to be notified on which topic
     let mut notifications = persistency::NotificationStore::new(&configuration);
 

--- a/up-subscription/src/persistency.rs
+++ b/up-subscription/src/persistency.rs
@@ -773,10 +773,8 @@ mod tests {
     #[test_case(TopicState::SUBSCRIBE_PENDING, &[1,0,0,0]; "State SUBSCRIBE_PENDING")]
     #[test_case(TopicState::SUBSCRIBED, &[2,0,0,0]; "State SUBSCRIBED")]
     #[test_case(TopicState::UNSUBSCRIBE_PENDING, &[3,0,0,0]; "State UNSUBSCRIBE_PENDING")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_serialize_deserialize_topic_state(state: TopicState, bytes: &[u8]) {
-        helpers::init_once();
-
         // One way...
         let serialized_bytes = serialize_topic_state(&state);
         assert!(serialized_bytes.is_ok());
@@ -792,10 +790,8 @@ mod tests {
         assert_eq!(reconstructed_state, state);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_validate_and_append_filename_success() {
-        helpers::init_once();
-
         let mut expected = PathBuf::from(".");
         expected.push("newfile");
 
@@ -809,10 +805,8 @@ mod tests {
     #[test_case( "\\"; "Relative path 3")]
     #[test_case( ""; "Empty filename")]
     #[test_case( "/dummy/newfile"; "Random path and name")]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_validate_and_append_filename_relative_paths(file: &str) {
-        helpers::init_once();
-
         let r = validate_and_append_filename(&PathBuf::from("."), file);
         assert!(r.is_err());
     }

--- a/up-subscription/src/subscription_manager.rs
+++ b/up-subscription/src/subscription_manager.rs
@@ -11,15 +11,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use log::*;
 #[cfg(test)]
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
+
 use tokio::{
     sync::{mpsc, mpsc::Receiver, mpsc::Sender, oneshot, Notify},
     time::sleep,
 };
-
+use tracing::{debug, error, warn};
 use up_rust::{
     communication::{CallOptions, InMemoryRpcClient, RpcClient},
     core::usubscription::{
@@ -147,8 +147,6 @@ pub(crate) async fn handle_message(
     notification_sender: Sender<NotificationEvent>,
     shutdown: Arc<Notify>,
 ) {
-    helpers::init_once();
-
     // track subscribers for topics - if you're in this list, you have SUBSCRIBED, otherwise you're considered UNSUBSCRIBED
     // [impl->req~usubscription-subscribe-persistency~1]
     let mut subscriptions = persistency::SubscriptionsStore::new(&configuration);
@@ -833,10 +831,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-subscribe-expiration~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_schedule_future_unsubscribe() {
-        helpers::init_once();
-
         let (internal_cmd_sender, mut internal_cmd_receiver) =
             mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
 
@@ -871,10 +867,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-subscribe-expiration~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_schedule_past_unsubscribe() {
-        helpers::init_once();
-
         let (internal_cmd_sender, mut internal_cmd_receiver) =
             mpsc::channel::<InternalSubscriptionEvent>(INTERNAL_COMMAND_BUFFER_SIZE);
 
@@ -908,10 +902,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_remote_subscribe() {
-        helpers::init_once();
-
         let expected_topic = test_lib::helpers::remote_topic1_uri();
 
         // build request
@@ -961,9 +953,8 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_remote_unsubscribe() {
-        helpers::init_once();
         let expected_topic = test_lib::helpers::remote_topic1_uri();
 
         // build request

--- a/up-subscription/src/tests/notification_manager_tests.rs
+++ b/up-subscription/src/tests/notification_manager_tests.rs
@@ -56,7 +56,7 @@ mod tests {
         fn new(config: Arc<USubscriptionConfiguration>, expected_message: Vec<UMessage>) -> Self {
             let shutdown_notification = Arc::new(Notify::new());
             let (command_sender, command_receiver) =
-                mpsc::channel::<NotificationEvent>(DEFAULT_COMMAND_BUFFER_SIZE);
+                mpsc::channel::<NotificationEvent>(DEFAULT_COMMAND_BUFFER_SIZE.into());
             let transport_mock =
                 test_lib::mocks::utransport_mock_for_notification_manager(expected_message);
 
@@ -143,9 +143,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_add_notifyee() {
-        helpers::init_once();
         let command_sender = CommandSender::new(Arc::new(CommandSender::get_config()), vec![]);
 
         let expected_subscriber = test_lib::helpers::subscriber_info1().uri.unwrap();
@@ -166,9 +165,8 @@ mod tests {
         assert!(notification_topics.contains(&(expected_subscriber, expected_topic)));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_remove_notifyee() {
-        helpers::init_once();
         let command_sender = CommandSender::new(Arc::new(CommandSender::get_config()), vec![]);
 
         // prepare things
@@ -201,10 +199,8 @@ mod tests {
 
     // [utest->dsn~usubscription-change-notification-type~1]
     // [utest->dsn~usubscription-change-notification-topic~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_state_change() {
-        helpers::init_once();
-
         // prepare things
         // this is the status&topic&subscriber that the notification is about
         let changing_status = SubscriptionStatus {
@@ -247,10 +243,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-register-notifications~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_state_change_direct_notification() {
-        helpers::init_once();
-
         // prepare things
         // this is the status&topic&subscriber that the notification is about
         let changing_status = SubscriptionStatus {
@@ -312,10 +306,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-unregister-notifications~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_unregister_direct_notification() {
-        helpers::init_once();
-
         // prepare things
         // this is the status&topic&subscriber that the notification is about
         let changing_status = SubscriptionStatus {

--- a/up-subscription/src/tests/persistency_tests.rs
+++ b/up-subscription/src/tests/persistency_tests.rs
@@ -16,7 +16,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::time::{sleep, Duration};
 
-    use crate::{helpers, persistency, test_lib, USubscriptionConfiguration};
+    use crate::{persistency, test_lib, USubscriptionConfiguration};
 
     fn get_configuration() -> USubscriptionConfiguration {
         USubscriptionConfiguration::create(
@@ -29,10 +29,8 @@ mod tests {
         .unwrap()
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_get_and_prune_expiring_subscriptions() {
-        helpers::init_once();
-
         let mut subscriptions = persistency::SubscriptionsStore::new(&get_configuration());
 
         // Prepare subscription persistency with two subscriptions, one with and one without expiry timestamp
@@ -88,10 +86,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-reset~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_reset_subscriptions() {
-        helpers::init_once();
-
         let mut subscriptions = persistency::SubscriptionsStore::new(&get_configuration());
 
         let _ = subscriptions.add_subscription(
@@ -118,10 +114,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-reset~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_reset_remote_subscriptions() {
-        helpers::init_once();
-
         let mut remote_topics = persistency::RemoteTopicsStore::new(&get_configuration());
 
         let _ = remote_topics.add_topic_or_get_state(&test_lib::helpers::local_topic1_uri());
@@ -140,10 +134,8 @@ mod tests {
     }
 
     // [utest->req~usubscription-reset~1]
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_reset_notifications() {
-        helpers::init_once();
-
         let mut notifications = persistency::NotificationStore::new(&get_configuration());
 
         notifications
@@ -172,10 +164,8 @@ mod tests {
         assert_eq!(data.unwrap().len(), 0);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_one_subscriber_multiple_topics() {
-        helpers::init_once();
-
         let mut notifications = persistency::NotificationStore::new(&get_configuration());
 
         let _ = notifications.add_notifyee(
@@ -193,10 +183,8 @@ mod tests {
         assert_eq!(data.unwrap().len(), 2);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_multiple_subscribers_one_topic() {
-        helpers::init_once();
-
         let mut notifications = persistency::NotificationStore::new(&get_configuration());
 
         let _ = notifications.add_notifyee(


### PR DESCRIPTION
Changed usubscription library to use generic tracing framework instead
of depending on env_logger crate. This allows users of the library
to choose their own logging backend.

Also updated up-subscription-cli to use tracing_subscriber as logging
backend and set up logging accordingly.

Removed obsolete None transport and related code and improved command
line argument handling for transport selection in up-subscription-cli.