### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-FROM rust:slim as build
+FROM rust:trixie AS build
+
+RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 
 # create a new empty shell project
 RUN USER=root mkdir /up-subscription-rust


### PR DESCRIPTION
- update to fully-featured Rust build image (address missing Perl module for OpenSSL build)
- install cmake to make paho-mqtt build work